### PR TITLE
feat: PID issuing [SIW-313]

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -112,18 +112,8 @@ export default function App() {
       // PAR request
       await issuingPID.getPar(unsignedJwtForPar, parSignature);
 
-      //Generate fresh keys for DPoP
-      const dPopKeyTag = Math.random().toString(36).substr(2, 5);
-      const dPopKey = await generate(dPopKeyTag);
-
-      const unsignedDPopForToken = await issuingPID.getUnsignedDPoP(dPopKey);
-      const dPopTokenSignature = await sign(unsignedDPopForToken, dPopKeyTag);
-
       // Token request
-      const authToken = await issuingPID.getAuthToken(
-        unsignedDPopForToken,
-        dPopTokenSignature
-      );
+      const authToken = await issuingPID.getAuthToken();
 
       // Generate fresh key for PID binding
       const pidKeyTag = Math.random().toString(36).substr(2, 5);
@@ -154,7 +144,7 @@ export default function App() {
         }
       );
 
-      setResult(JSON.stringify(pid.credential));
+      setResult(JSON.stringify(pid));
     } catch (e) {
       console.error(e);
       showError(e);

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -11,8 +11,10 @@ import {
 } from "react-native";
 
 import { PID, WalletInstanceAttestation } from "@pagopa/io-react-native-wallet";
+import { thumbprint } from "@pagopa/io-react-native-jwt";
 
 const walletProviderBaseUrl = "https://io-d-wallet-it.azurewebsites.net";
+const pidProviderBaseUrl = "https://api.wakala.it/it-pid-provider/";
 
 const pidToken =
   "eyJhbGciOiJFUzI1NiIsImtpZCI6IjV0NVlZcEJoTi1FZ0lFRUk1aVV6cjZyME1SMDJMblZRME9tZWttTktjalkiLCJ0cnVzdF9jaGFpbiI6W10sInR5cCI6InZjK3NkLWp3dCJ9.eyJzdWIiOiJMeExqRXJNUkd5cTRmb0ZCODh1TUxiVFQ2cS1rUHNITDhNTGktYloyUWRVIiwidmVyaWZpZWRfY2xhaW1zIjp7ImNsYWltcyI6eyJfc2QiOlsiSTllS2R6dk5oQWd1V3pGdFhPMmZiVUNaVWFoUDlwZkVaVXJaamhldGFEYyIsIm85OFVkeV90aVlvZzVJWFVibDVoMnJDSHhLYnljU1c0RDQ4Uno2V3JlejQiLCJaN3Fja1RnUjc0WjM2TFhtaDBXOFV0WkVka0Jta1pzUjVCTzRTenc3ZzY4IiwiMGswYTRoeXgyeWNHQVlITFFpMWJ4UU9MdnUzUUktdmNyYUZOLUFzX3VnMCIsIlZDV1NpY2w4cWcyUEcxN0VTSFN3NVBMdEFCdldYTy1oakR1TURuME5KTjQiLCI1QWJKOVlTRTR6TW9DTUZ6ZW4xMTV2QWtmSjJKc25qMVJ1WDVZb0ZkUzNJIl19LCJ2ZXJpZmljYXRpb24iOnsidHJ1c3RfZnJhbWV3b3JrIjoiZWlkYXMiLCJhc3N1cmFuY2VfbGV2ZWwiOiJoaWdoIiwiX3NkIjpbImZZZUVNcWE5WEFuQXQ0OFdmcVZlejQwSW1jVk1Jc1plYkp4a3F5TmlKcUEiXX19LCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MCIsImNuZiI6eyJqd2siOnsiY3J2IjoiUC0yNTYiLCJrdHkiOiJFQyIsIngiOiJxckpyajNBZl9CNTdzYk9JUnJjQk03YnI3d09jOHluajdsSEZQVGVmZlVrIiwieSI6IjFIMGNXRHlHZ3ZVOHcta1BLVV94eWNPQ1VOVDJvMGJ3c2xJUXRuUFU2aU0iLCJraWQiOiI1dDVZWXBCaE4tRWdJRUVJNWlVenI2cjBNUjAyTG5WUTBPbWVrbU5LY2pZIn19LCJ0eXBlIjoiUGVyc29uSWRlbnRpZmljYXRpb25EYXRhIiwianRpIjoidXJuOnV1aWQ6YTQ0MmEzNDAtYjM4ZS00OWMzLTlkNDktZjc1OWY0MDgzMWU2Iiwic3RhdHVzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3N0YXR1cyIsImlhdCI6MTY4OTY5MzU1OSwiZXhwIjoyMDA1MjY5NTU5fQ.tpgf0oo0-RJxkL98ipw5xX3ftEmZw-fQVA2c2aM1gZ_jfcDXE2_Xs2aMpT0hy7w4IhP5V0B0HmXtTVYXwVu8kQ~WyJyYzQ0Z3ZRUy1TNDFFUDhSVU1pdFRRIiwiZXZpZGVuY2UiLFt7InR5cGUiOiJlbGVjdHJvbmljX3JlY29yZCIsInJlY29yZCI6eyJ0eXBlIjoiZWlkYXMuaXQuY2llIiwic291cmNlIjp7Im9yZ2FuaXphdGlvbl9uYW1lIjoiTWluaXN0ZXJvIGRlbGwnSW50ZXJubyIsIm9yZ2FuaXphdGlvbl9pZCI6Im1faXQiLCJjb3VudHJ5X2NvZGUiOiJJVCJ9fX1dXQ~WyI2dzFfc29SWEZnYUhLZnBZbjNjdmZRIiwiZ2l2ZW5fbmFtZSIsIk1hcmlvIl0~WyJoNlQ3MXIycVZmMjlsNXhCNnUzdWx3IiwiZmFtaWx5X25hbWUiLCJSb3NzaSJd~WyJvR29iQl9uZXRZMEduS3hUN3hsVTRBIiwidW5pcXVlX2lkIiwiaWRBTlBSIl0~WyJmdU5wOTdIZjN3VjZ5NDh5LVFaaElnIiwiYmlydGhkYXRlIiwiMTk4MC0xMC0wMSJd~WyJwLTlMenlXSFpCVkR2aFhEV2tOMnhBIiwicGxhY2Vfb2ZfYmlydGgiLHsiY291bnRyeSI6IklUIiwibG9jYWxpdHkiOiJSb21lIn1d~WyI5UnFLdWwzeHh6R2I4X1J1Zm5BSmZRIiwidGF4X2lkX251bWJlciIsIlRJTklULVJTU01SQTgwQTEwSDUwMUEiXQ";
@@ -44,23 +46,75 @@ export default function App() {
 
   const getAttestation = async () => {
     try {
-      const randomKeyTag = Math.random().toString(36).substr(2, 5);
-      const publicKey = await generate(randomKeyTag);
+      const walletInstanceKeyTag = Math.random().toString(36).substr(2, 5);
+      const walletInstancePublicKey = await generate(walletInstanceKeyTag);
       const issuingAttestation = new WalletInstanceAttestation.Issuing(
         walletProviderBaseUrl
       );
 
       const attestationRequest =
-        await issuingAttestation.getAttestationRequestToSign(publicKey);
+        await issuingAttestation.getAttestationRequestToSign(
+          walletInstancePublicKey
+        );
 
-      const signature = await sign(attestationRequest, randomKeyTag);
+      const signature = await sign(attestationRequest, walletInstanceKeyTag);
       const instanceAttestation = await issuingAttestation.getAttestation(
         attestationRequest,
         signature
       );
 
+      console.log(instanceAttestation);
       setResult(JSON.stringify(instanceAttestation));
-      console.error(instanceAttestation);
+
+      // START PID
+      const walletInstanceKeyThumbprint = await thumbprint(
+        walletInstancePublicKey
+      );
+      const issuingPID = new PID.Issuing(
+        pidProviderBaseUrl,
+        walletProviderBaseUrl,
+        instanceAttestation,
+        walletInstanceKeyThumbprint
+      );
+
+      const unsignedJwtForPar = await issuingPID.getUnsignedJwtForPar(
+        walletInstancePublicKey
+      );
+      const parSignature = await sign(unsignedJwtForPar, walletInstanceKeyTag);
+      await issuingPID.getPar(unsignedJwtForPar, parSignature);
+
+      //Key for dpop
+      const dPopKeyTag = Math.random().toString(36).substr(2, 5);
+      const dPopKey = await generate(dPopKeyTag);
+
+      const unsignedDPopForToken = await issuingPID.getUnsignedDPop(dPopKey);
+      const dPopTokenSignature = await sign(unsignedDPopForToken, dPopKeyTag);
+      const authToken = await issuingPID.getAuthToken(
+        unsignedDPopForToken,
+        dPopTokenSignature
+      );
+
+      const pidKeyTag = Math.random().toString(36).substr(2, 5);
+      const pidKey = await generate(pidKeyTag);
+
+      const unsignedDPopForPid = await issuingPID.getUnsignedDPop(pidKey);
+      const dPopPidSignature = await sign(unsignedDPopForPid, pidKeyTag);
+
+      const unsignedProof = await issuingPID.getUnsignedProof(
+        authToken.c_nonce
+      );
+      const proofSignature = await sign(unsignedProof, pidKeyTag);
+
+      const credential = await issuingPID.getCredential(
+        unsignedDPopForPid,
+        dPopPidSignature,
+        unsignedProof,
+        proofSignature,
+        authToken.access_token
+      );
+
+      console.log(credential);
+      setResult(JSON.stringify(credential));
     } catch (e) {
       console.error(e);
       showError(e);

--- a/package.json
+++ b/package.json
@@ -66,13 +66,15 @@
     "react": "18.2.0",
     "react-native": "0.71.8",
     "react-native-builder-bob": "^0.20.0",
-    "typescript": "^5.0.2"
+    "typescript": "^5.0.2",
+    "@pagopa/io-react-native-crypto": "^0.2.3"
   },
   "resolutions": {
     "@types/react": "17.0.21"
   },
   "peerDependencies": {
     "@pagopa/io-react-native-jwt": "*",
+    "@pagopa/io-react-native-crypto": "*",
     "react": "*",
     "react-native": "*"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-wallet",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Provide data structures, helpers and API for IO Wallet",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,5 @@ import * as RP from "./rp";
 import * as Errors from "./utils/errors";
 import * as WalletInstanceAttestation from "./wallet-instance-attestation";
 import { getUnsignedDPop } from "./utils/dpop";
-import { getSignedJwt } from "./utils/signature";
 
-export {
-  PID,
-  RP,
-  WalletInstanceAttestation,
-  Errors,
-  getUnsignedDPop,
-  getSignedJwt,
-};
+export { PID, RP, WalletInstanceAttestation, Errors, getUnsignedDPop };

--- a/src/pid/index.ts
+++ b/src/pid/index.ts
@@ -1,2 +1,3 @@
 import * as SdJwt from "./sd-jwt";
-export { SdJwt };
+import { Issuing } from "./issuing";
+export { SdJwt, Issuing };

--- a/src/pid/issuing.ts
+++ b/src/pid/issuing.ts
@@ -195,6 +195,7 @@ export class Issuing {
     unsignedProof: string,
     signature: string,
     accessToken: string,
+    cieData: any,
     appFetch: GlobalFetch = { fetch }
   ): Promise<TokenResponse> {
     const signedDPopForPid = await SignJWT.appendSignature(
@@ -209,12 +210,7 @@ export class Issuing {
       format: "vc+sd-jwt",
       proof: JSON.stringify({
         jwt: signedProof,
-        cieData: {
-          birthDate: "",
-          fiscalCode: "",
-          name: "FRANCESCO",
-          surname: "GRAUSO",
-        },
+        cieData,
         proof_type: "jwt",
       }),
     };

--- a/src/pid/issuing.ts
+++ b/src/pid/issuing.ts
@@ -6,9 +6,24 @@ import {
 import { SignJWT, thumbprint } from "@pagopa/io-react-native-jwt";
 import { JWK } from "../utils/jwk";
 import uuid from "react-native-uuid";
-import { IoWalletError } from "../utils/errors";
+import { PidIssuingError } from "../utils/errors";
+import { getUnsignedDPop } from "../utils/dpop";
+
+// This is a temporary type that will be used for demo purposes only
+export type CieData = {
+  birthDate: string;
+  fiscalCode: string;
+  name: string;
+  surname: string;
+};
 
 export type TokenResponse = { access_token: string; c_nonce: string };
+export type PidResponse = {
+  credential: string;
+  c_nonce: string;
+  c_nonce_expires_in: number;
+  format: string;
+};
 
 export class Issuing {
   pidProviderBaseUrl: string;
@@ -18,12 +33,14 @@ export class Issuing {
   clientId: string;
   state: string;
   authorizationCode: string;
+  appFetch: GlobalFetch["fetch"];
 
   constructor(
     pidProviderBaseUrl: string,
     walletProviderBaseUrl: string,
     walletInstanceAttestation: string,
-    clientId: string
+    clientId: string,
+    appFetch: GlobalFetch["fetch"] = fetch
   ) {
     this.pidProviderBaseUrl = pidProviderBaseUrl;
     this.walletProviderBaseUrl = walletProviderBaseUrl;
@@ -32,8 +49,18 @@ export class Issuing {
     this.authorizationCode = `${uuid.v4()}`;
     this.walletInstanceAttestation = walletInstanceAttestation;
     this.clientId = clientId;
+    this.appFetch = appFetch;
   }
 
+  /**
+   * Return the unsigned jwt to call the PAR request.
+   *
+   * @function
+   * @param jwk The wallet instance attestation public JWK
+   *
+   * @returns Unsigned jwt
+   *
+   */
   async getUnsignedJwtForPar(jwk: JWK): Promise<string> {
     const parsedJwk = JWK.parse(jwk);
     const keyThumbprint = await thumbprint(parsedJwk);
@@ -70,11 +97,17 @@ export class Issuing {
     return unsignedJwtForPar;
   }
 
-  async getPar(
-    unsignedJwtForPar: string,
-    signature: string,
-    appFetch: GlobalFetch = { fetch }
-  ): Promise<string> {
+  /**
+   * Make a PAR request to the PID issuer and return the response url
+   *
+   * @function
+   * @param unsignedJwtForPar The unsigned JWT for PAR
+   * @param signature The JWT for PAR signature
+   *
+   * @returns Unsigned PAR url
+   *
+   */
+  async getPar(unsignedJwtForPar: string, signature: string): Promise<string> {
     const codeChallenge = await sha256ToBase64(this.codeVerifier);
     const signedJwtForPar = await SignJWT.appendSignature(
       unsignedJwtForPar,
@@ -96,7 +129,7 @@ export class Issuing {
 
     var formBody = new URLSearchParams(requestBody);
 
-    const response = await appFetch.fetch(parUrl, {
+    const response = await this.appFetch(parUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -109,35 +142,45 @@ export class Issuing {
       return result.request_uri;
     }
 
-    throw new IoWalletError(
+    throw new PidIssuingError(
       `Unable to obtain PAR. Response code: ${await response.text()}`
     );
   }
 
-  async getUnsignedDPop(jwk: JWK): Promise<string> {
+  /**
+   * Return the unsigned jwt for a generic DPoP
+   *
+   * @function
+   * @param jwk the public key for which the DPoP is to be created
+   *
+   * @returns Unsigned JWT for DPoP
+   *
+   */
+  async getUnsignedDPoP(jwk: JWK): Promise<string> {
     const tokenUrl = new URL("/token", this.pidProviderBaseUrl).href;
-    const dPop = new SignJWT({
+    const dPop = getUnsignedDPop(jwk, {
       htm: "POST",
       htu: tokenUrl,
       jti: `${uuid.v4()}`,
-    })
-      .setProtectedHeader({
-        alg: "ES256",
-        type: "dpop+jwt",
-        jwk,
-      })
-      .setIssuedAt()
-      .setExpirationTime("1h")
-      .toSign();
+    });
     return dPop;
   }
 
+  /**
+   * Make an auth token request to the PID issuer
+   *
+   * @function
+   * @param unsignedDPopForToken The unsigned JWT for DPoP
+   * @param signature The JWT for PAR signature
+   *
+   * @returns a token response
+   *
+   */
   async getAuthToken(
     unsignedDPopForToken: string,
-    signature: string,
-    appFetch: GlobalFetch = { fetch }
+    signature: string
   ): Promise<TokenResponse> {
-    let signedDPop = await SignJWT.appendSignature(
+    const signedDPop = await SignJWT.appendSignature(
       unsignedDPopForToken,
       signature
     );
@@ -155,7 +198,7 @@ export class Issuing {
     };
     var formBody = new URLSearchParams(requestBody);
 
-    const response = await appFetch.fetch(tokenUrl, {
+    const response = await this.appFetch(tokenUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -168,12 +211,21 @@ export class Issuing {
       return await response.json();
     }
 
-    throw new IoWalletError(
+    throw new PidIssuingError(
       `Unable to obtain token. Response code: ${await response.text()}`
     );
   }
 
-  async getUnsignedProof(nonce: string): Promise<string> {
+  /**
+   * Return the unsigned jwt for nonce proof of possession
+   *
+   * @function
+   * @param nonce the nonce
+   *
+   * @returns Unsigned JWT for nonce proof
+   *
+   */
+  async getUnsignedNonceProof(nonce: string): Promise<string> {
     const unsignedProof = new SignJWT({
       nonce,
     })
@@ -189,34 +241,50 @@ export class Issuing {
     return unsignedProof;
   }
 
+  /**
+   * Make the credential issuing request to the PID issuer
+   *
+   * @function
+   * @param unsignedDPopForPid The unsigned JWT for PID DPoP
+   * @param dPopPidSignature The JWT for PID DPoP signature
+   * @param unsignedNonceProof The unsigned JWT for nonce proof
+   * @param nonceProofSignature The JWT for nonce proof signature
+   * @param accessToken The access token obtained with getAuthToken
+   * @param cieData Personal data read by the CIE
+   *
+   * @returns a credential
+   *
+   */
   async getCredential(
     unsignedDPopForPid: string,
     dPopPidSignature: string,
-    unsignedProof: string,
-    signature: string,
+    unsignedNonceProof: string,
+    nonceProofSignature: string,
     accessToken: string,
-    cieData: any,
-    appFetch: GlobalFetch = { fetch }
-  ): Promise<TokenResponse> {
+    cieData: CieData
+  ): Promise<PidResponse> {
     const signedDPopForPid = await SignJWT.appendSignature(
       unsignedDPopForPid,
       dPopPidSignature
     );
-    const signedProof = await SignJWT.appendSignature(unsignedProof, signature);
+    const signedNonceProof = await SignJWT.appendSignature(
+      unsignedNonceProof,
+      nonceProofSignature
+    );
     const credentialUrl = new URL("/credential", this.pidProviderBaseUrl).href;
 
     const requestBody = {
       credential_definition: JSON.stringify({ type: ["eu.eudiw.pid.it"] }),
       format: "vc+sd-jwt",
       proof: JSON.stringify({
-        jwt: signedProof,
+        jwt: signedNonceProof,
         cieData,
         proof_type: "jwt",
       }),
     };
-    var formBody = new URLSearchParams(requestBody);
+    const formBody = new URLSearchParams(requestBody);
 
-    const response = await appFetch.fetch(credentialUrl, {
+    const response = await this.appFetch(credentialUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -230,6 +298,6 @@ export class Issuing {
       return await response.json();
     }
 
-    throw new IoWalletError(`Unable to obtain credential`);
+    throw new PidIssuingError(`Unable to obtain credential!`);
   }
 }

--- a/src/pid/issuing.ts
+++ b/src/pid/issuing.ts
@@ -1,0 +1,239 @@
+import {
+  decode as decodeJwt,
+  sha256ToBase64,
+} from "@pagopa/io-react-native-jwt";
+
+import { SignJWT, thumbprint } from "@pagopa/io-react-native-jwt";
+import { JWK } from "../utils/jwk";
+import uuid from "react-native-uuid";
+import { IoWalletError } from "../utils/errors";
+
+export type TokenResponse = { access_token: string; c_nonce: string };
+
+export class Issuing {
+  pidProviderBaseUrl: string;
+  walletProviderBaseUrl: string;
+  walletInstanceAttestation: string;
+  codeVerifier: string;
+  clientId: string;
+  state: string;
+  authorizationCode: string;
+
+  constructor(
+    pidProviderBaseUrl: string,
+    walletProviderBaseUrl: string,
+    walletInstanceAttestation: string,
+    clientId: string
+  ) {
+    this.pidProviderBaseUrl = pidProviderBaseUrl;
+    this.walletProviderBaseUrl = walletProviderBaseUrl;
+    this.state = `${uuid.v4()}`;
+    this.codeVerifier = `${uuid.v4()}`;
+    this.authorizationCode = `${uuid.v4()}`;
+    this.walletInstanceAttestation = walletInstanceAttestation;
+    this.clientId = clientId;
+  }
+
+  async getUnsignedJwtForPar(jwk: JWK): Promise<string> {
+    const parsedJwk = JWK.parse(jwk);
+    const keyThumbprint = await thumbprint(parsedJwk);
+    const publicKey = { ...parsedJwk, kid: keyThumbprint };
+    const codeChallenge = await sha256ToBase64(this.codeVerifier);
+
+    const unsignedJwtForPar = new SignJWT({
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      authorization_details: [
+        {
+          credentialDefinition: {
+            type: ["eu.eudiw.pid.it"],
+          },
+          format: "vc+sd-jwt",
+          type: "type",
+        },
+      ],
+      response_type: "code",
+      code_challenge_method: "s256",
+      redirect_uri: this.walletProviderBaseUrl,
+      state: this.state,
+      client_id: this.clientId,
+      code_challenge: codeChallenge,
+    })
+      .setProtectedHeader({
+        alg: "ES256",
+        kid: publicKey.kid,
+      })
+      .setIssuedAt()
+      .setExpirationTime("1h")
+      .toSign();
+
+    return unsignedJwtForPar;
+  }
+
+  async getPar(
+    unsignedJwtForPar: string,
+    signature: string,
+    appFetch: GlobalFetch = { fetch }
+  ): Promise<string> {
+    const codeChallenge = await sha256ToBase64(this.codeVerifier);
+    const signedJwtForPar = await SignJWT.appendSignature(
+      unsignedJwtForPar,
+      signature
+    );
+
+    const parUrl = new URL("/as/par", this.pidProviderBaseUrl).href;
+
+    const requestBody = {
+      response_type: "code",
+      client_id: this.clientId,
+      code_challenge: codeChallenge,
+      code_challenge_method: "S256",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      client_assertion: this.walletInstanceAttestation,
+      request: signedJwtForPar,
+    };
+
+    var formBody = new URLSearchParams(requestBody);
+
+    const response = await appFetch.fetch(parUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: formBody.toString(),
+    });
+
+    if (response.status === 201) {
+      const result = await response.json();
+      return result.request_uri;
+    }
+
+    throw new IoWalletError(
+      `Unable to obtain PAR. Response code: ${await response.text()}`
+    );
+  }
+
+  async getUnsignedDPop(jwk: JWK): Promise<string> {
+    const tokenUrl = new URL("/token", this.pidProviderBaseUrl).href;
+    const dPop = new SignJWT({
+      htm: "POST",
+      htu: tokenUrl,
+      jti: `${uuid.v4()}`,
+    })
+      .setProtectedHeader({
+        alg: "ES256",
+        type: "dpop+jwt",
+        jwk,
+      })
+      .setIssuedAt()
+      .setExpirationTime("1h")
+      .toSign();
+    return dPop;
+  }
+
+  async getAuthToken(
+    unsignedDPopForToken: string,
+    signature: string,
+    appFetch: GlobalFetch = { fetch }
+  ): Promise<TokenResponse> {
+    let signedDPop = await SignJWT.appendSignature(
+      unsignedDPopForToken,
+      signature
+    );
+    const decodedJwtDPop = decodeJwt(signedDPop);
+    const tokenUrl = decodedJwtDPop.payload.htu as string;
+    const requestBody = {
+      grant_type: "authorization code",
+      client_id: this.clientId,
+      code: this.authorizationCode,
+      code_verifier: this.codeVerifier,
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      client_assertion: this.walletInstanceAttestation,
+      redirect_uri: this.walletProviderBaseUrl,
+    };
+    var formBody = new URLSearchParams(requestBody);
+
+    const response = await appFetch.fetch(tokenUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        DPoP: signedDPop,
+      },
+      body: formBody.toString(),
+    });
+
+    if (response.status === 200) {
+      return await response.json();
+    }
+
+    throw new IoWalletError(
+      `Unable to obtain token. Response code: ${await response.text()}`
+    );
+  }
+
+  async getUnsignedProof(nonce: string): Promise<string> {
+    const unsignedProof = new SignJWT({
+      nonce,
+    })
+      .setProtectedHeader({
+        alg: "ES256",
+        type: "openid4vci-proof+jwt",
+      })
+      .setAudience(this.walletProviderBaseUrl)
+      .setIssuer(this.clientId)
+      .setIssuedAt()
+      .setExpirationTime("1h")
+      .toSign();
+    return unsignedProof;
+  }
+
+  async getCredential(
+    unsignedDPopForPid: string,
+    dPopPidSignature: string,
+    unsignedProof: string,
+    signature: string,
+    accessToken: string,
+    appFetch: GlobalFetch = { fetch }
+  ): Promise<TokenResponse> {
+    const signedDPopForPid = await SignJWT.appendSignature(
+      unsignedDPopForPid,
+      dPopPidSignature
+    );
+    const signedProof = await SignJWT.appendSignature(unsignedProof, signature);
+    const credentialUrl = new URL("/credential", this.pidProviderBaseUrl).href;
+
+    const requestBody = {
+      credential_definition: JSON.stringify({ type: ["eu.eudiw.pid.it"] }),
+      format: "vc+sd-jwt",
+      proof: JSON.stringify({
+        jwt: signedProof,
+        cieData: {
+          birthDate: "",
+          fiscalCode: "",
+          name: "FRANCESCO",
+          surname: "GRAUSO",
+        },
+        proof_type: "jwt",
+      }),
+    };
+    var formBody = new URLSearchParams(requestBody);
+
+    const response = await appFetch.fetch(credentialUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        DPoP: signedDPopForPid,
+        Authorization: accessToken,
+      },
+      body: formBody.toString(),
+    });
+
+    if (response.status === 200) {
+      return await response.json();
+    }
+
+    throw new IoWalletError(`Unable to obtain credential`);
+  }
+}

--- a/src/sd-jwt/index.ts
+++ b/src/sd-jwt/index.ts
@@ -36,6 +36,7 @@ export const decode = <S extends z.AnyZodObject>(
     header: decodedJwt.protectedHeader,
     payload: decodedJwt.payload,
   });
+  console.log(rawDisclosures);
 
   // get disclosures as list of triples
   // validate each triple

--- a/src/sd-jwt/index.ts
+++ b/src/sd-jwt/index.ts
@@ -36,7 +36,6 @@ export const decode = <S extends z.AnyZodObject>(
     header: decodedJwt.protectedHeader,
     payload: decodedJwt.payload,
   });
-  console.log(rawDisclosures);
 
   // get disclosures as list of triples
   // validate each triple

--- a/src/sd-jwt/types.ts
+++ b/src/sd-jwt/types.ts
@@ -25,7 +25,7 @@ export const SdJwt4VC = z.object({
   header: z.object({
     typ: z.literal("vc+sd-jwt"),
     alg: z.string(),
-    kid: z.string(),
+    kid: z.string().optional(),
     trust_chain: z.array(z.string()),
   }),
   payload: z.object({

--- a/src/utils/dpop.ts
+++ b/src/utils/dpop.ts
@@ -21,5 +21,5 @@ export const DPoPPayload = z.object({
   jti: z.string(),
   htm: z.union([z.literal("POST"), z.literal("GET")]),
   htu: z.string(),
-  ath: z.string(),
+  ath: z.string().optional(),
 });

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -96,3 +96,27 @@ export class AuthRequestDecodeError extends IoWalletError {
     this.reason = reason;
   }
 }
+
+/**
+ * An error subclass thrown when validation fail
+ *
+ */
+export class PidIssuingError extends IoWalletError {
+  static get code(): "ERR_IO_WALLET_PID_ISSUING_FAILED" {
+    return "ERR_IO_WALLET_PID_ISSUING_FAILED";
+  }
+
+  code = "ERR_IO_WALLET_PID_ISSUING_FAILED";
+
+  /** The Claim for which the validation failed. */
+  claim: string;
+
+  /** Reason code for the validation failure. */
+  reason: string;
+
+  constructor(message: string, claim = "unspecified", reason = "unspecified") {
+    super(message);
+    this.claim = claim;
+    this.reason = reason;
+  }
+}

--- a/src/utils/signature.ts
+++ b/src/utils/signature.ts
@@ -1,4 +1,0 @@
-import { SignJWT } from "@pagopa/io-react-native-jwt";
-
-export const getSignedJwt = async (unsignedJwt: string, signature: string) =>
-  await SignJWT.appendSignature(unsignedJwt, signature);

--- a/src/wallet-instance-attestation/issuing.ts
+++ b/src/wallet-instance-attestation/issuing.ts
@@ -69,7 +69,7 @@ export class Issuing {
   async getAttestation(
     attestationRequest: string,
     signature: string
-  ): Promise<String> {
+  ): Promise<string> {
     const signedAttestationRequest = await SignJWT.appendSignature(
       attestationRequest,
       signature

--- a/src/wallet-instance-attestation/issuing.ts
+++ b/src/wallet-instance-attestation/issuing.ts
@@ -67,7 +67,7 @@ export class Issuing {
     attestationRequest: string,
     signature: string,
     appFetch: GlobalFetch = { fetch }
-  ): Promise<String> {
+  ): Promise<string> {
     const signedAttestationRequest = await SignJWT.appendSignature(
       attestationRequest,
       signature

--- a/yarn.lock
+++ b/yarn.lock
@@ -1628,6 +1628,11 @@
     eslint-plugin-sonarjs "^0.13.0"
     prettier "^2.6.2"
 
+"@pagopa/io-react-native-crypto@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-crypto/-/io-react-native-crypto-0.2.3.tgz#395a001e6fc831897dd979a7994950457b637328"
+  integrity sha512-cXJBwBsPUBxIFoTVXqlVc2zNgUuFPVdtIKu0WUyEGg8ZNOMGT9cRpE/qYx2uTY+hrYxtO8RKH6aXLsF43mYRBA==
+
 "@pagopa/io-react-native-jwt@^0.4.0":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-jwt/-/io-react-native-jwt-0.4.1.tgz#02e277e8ea2c46257a9c8debafafef41713c04ce"


### PR DESCRIPTION
Adds the integration towards the PID issuer for obtaining a PID credential.

#### List of Changes
- Added `PAR` request with JWT generator
- Added `auth token` request with DPoP generator
- Added `credential` request with proof on nonce generator

#### Motivation and Context
This PR ports the SDK made only for Android into typescript code

#### How Has This Been Tested?
Tested locally and through unit tests

#### How to use:
To understand how to get a PID refer to the `getPid` function within the sample app.

#### Checklist:
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
