### PR TITLE
feat: [SIW-351] Encrypt authorization response

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@pagopa/io-react-native-crypto": "^0.2.3",
-    "@pagopa/io-react-native-jwt": "^0.4.0",
+    "@pagopa/io-react-native-jwt": "^0.5.0",
     "expo": "~48.0.18",
     "expo-splash-screen": "~0.18.2",
     "expo-status-bar": "~1.4.4",

--- a/example/src/scenarios/cross-device-flow-with-rp.tsx
+++ b/example/src/scenarios/cross-device-flow-with-rp.tsx
@@ -69,6 +69,9 @@ export default async () => {
       DPoPSignature
     ).then((t) => RP.getRequestObject(t));
 
+    // resolve RP's entity configuration
+    const entity = await RP.getEntityConfiguration();
+
     // Attest Relying Party trust
     // TODO [SIW-354]
 
@@ -93,7 +96,7 @@ export default async () => {
     const vpToken = await SignJWT.appendSignature(unsignedVpToken, signature);
 
     // Submit authorization response
-    const ok = await RP.sendAuthorizationResponse(requestObj, vpToken);
+    const ok = await RP.sendAuthorizationResponse(requestObj, vpToken, entity);
 
     return result(ok);
   } catch (e) {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1733,10 +1733,10 @@
   resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-crypto/-/io-react-native-crypto-0.2.3.tgz#395a001e6fc831897dd979a7994950457b637328"
   integrity sha512-cXJBwBsPUBxIFoTVXqlVc2zNgUuFPVdtIKu0WUyEGg8ZNOMGT9cRpE/qYx2uTY+hrYxtO8RKH6aXLsF43mYRBA==
 
-"@pagopa/io-react-native-jwt@^0.4.0":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-jwt/-/io-react-native-jwt-0.4.1.tgz#02e277e8ea2c46257a9c8debafafef41713c04ce"
-  integrity sha512-jvyxF3ko3aJsLgHKoJNg/KGc1utq5WYtC85hPdG20GH5OiYuFCroFEFuN2G9wXfrOuwvYTHnpgaSpNO2ogGvaw==
+"@pagopa/io-react-native-jwt@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-jwt/-/io-react-native-jwt-0.5.0.tgz#117ed05173537a4f3143c9c0745c06ba8934e1cd"
+  integrity sha512-WG8V+M66n2+x+GZPMfvZkbpGumaf6bbu/XTpOe/eR609kVol29kU5T7gPNiIuXdbt8gmfumvSzU2jdvh2L5AzQ==
   dependencies:
     abab "^2.0.6"
 
@@ -10729,10 +10729,8 @@ watchpack@^1.6.1:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@pagopa/eslint-config": "^3.0.0",
     "@pagopa/io-react-native-crypto": "^0.2.3",
-    "@pagopa/io-react-native-jwt": "^0.4.0",
+    "@pagopa/io-react-native-jwt": "^0.5.0",
     "@react-native-community/eslint-config": "^3.2.0",
     "@rushstack/eslint-patch": "^1.3.2",
     "@types/jest": "^28.1.2",
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "@pagopa/io-react-native-crypto": "*",
-    "@pagopa/io-react-native-jwt": "*",
+    "@pagopa/io-react-native-jwt": "^0.5.0",
     "react": "*",
     "react-native": "*"
   },

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -144,3 +144,23 @@ export class ClaimsNotFoundBetweenDislosures extends Error {
     this.claims = c;
   }
 }
+
+/**
+ * When selecting a public key from an entity configuration, and no one meets the requirements for the scenario
+ *
+ */
+export class NoSuitableKeysFoundInEntityConfiguration extends Error {
+  static get code(): "ERR_NO_SUITABLE_KEYS_NOT_FOUND" {
+    return "ERR_NO_SUITABLE_KEYS_NOT_FOUND";
+  }
+
+  code = "ERR_NO_SUITABLE_KEYS_NOT_FOUND";
+
+  /**
+   * @param scenario describe the scenario in which the error arise
+   */
+  constructor(scenario: string) {
+    const message = `Entity configuration do not provide any suitable keys (${scenario}).`;
+    super(message);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,10 +1633,10 @@
   resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-crypto/-/io-react-native-crypto-0.2.3.tgz#395a001e6fc831897dd979a7994950457b637328"
   integrity sha512-cXJBwBsPUBxIFoTVXqlVc2zNgUuFPVdtIKu0WUyEGg8ZNOMGT9cRpE/qYx2uTY+hrYxtO8RKH6aXLsF43mYRBA==
 
-"@pagopa/io-react-native-jwt@^0.4.0":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-jwt/-/io-react-native-jwt-0.4.1.tgz#02e277e8ea2c46257a9c8debafafef41713c04ce"
-  integrity sha512-jvyxF3ko3aJsLgHKoJNg/KGc1utq5WYtC85hPdG20GH5OiYuFCroFEFuN2G9wXfrOuwvYTHnpgaSpNO2ogGvaw==
+"@pagopa/io-react-native-jwt@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-jwt/-/io-react-native-jwt-0.5.0.tgz#117ed05173537a4f3143c9c0745c06ba8934e1cd"
+  integrity sha512-WG8V+M66n2+x+GZPMfvZkbpGumaf6bbu/XTpOe/eR609kVol29kU5T7gPNiIuXdbt8gmfumvSzU2jdvh2L5AzQ==
   dependencies:
     abab "^2.0.6"
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* encrypt authorization response

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
As described in https://italia.github.io/eudi-wallet-it-docs/v0.4.1/en/relying-party-solution.html#authorization-response-details, authorization response payload must be encrypted in order to avoid SSL split attack vulnerabilities. 
Encryption has been made according to OpenID4VP specification https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-signed-and-encrypted-respon

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
