### PR TITLE
chore: [SIW-484] Integrate new Wallet Instance version 0.5.0

### DIFF
--- a/example/ios/IoReactNativeWalletExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/example/ios/IoReactNativeWalletExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/example/ios/example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/example/ios/example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-wallet",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Provide data structures, helpers and API for IO Wallet",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/wallet-instance-attestation/__tests__/index.test.ts
+++ b/src/wallet-instance-attestation/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { decode } from "..";
 
 // Wallet Instance Attestation
 const token =
-  "eyJhbGciOiJFUzI1NiIsImtpZCI6IjV0NVlZcEJoTi1FZ0lFRUk1aVV6cjZyME1SMDJMblZRME9tZWttTktjalkiLCJ0cnVzdF9jaGFpbiI6WyJleUpoYkdjaU9pSkZVei4uLjZTMEEiLCJleUpoYkdjaU9pSkZVei4uLmpKTEEiLCJleUpoYkdjaU9pSkZVei4uLkg5Z3ciXSwidHlwIjoidmErand0IiwieDVjIjpbIk1JSUJqRENDIC4uLiBYRmVoZ0tRQT09Il19.eyJpc3MiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZyIsInN1YiI6InZiZVhKa3NNNDV4cGh0QU5uQ2lHNm1DeXVVNGpmR056b3BHdUt2b2dnOWMiLCJ0eXBlIjoiV2FsbGV0SW5zdGFuY2VBdHRlc3RhdGlvbiIsInBvbGljeV91cmkiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9wcml2YWN5X3BvbGljeSIsInRvc191cmkiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9pbmZvX3BvbGljeSIsImxvZ29fdXJpIjoiaHR0cHM6Ly93YWxsZXQtcHJvdmlkZXIuZXhhbXBsZS5vcmcvbG9nby5zdmciLCJhc2MiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9Mb0EvYmFzaWMiLCJjbmYiOnsiandrIjp7ImNydiI6IlAtMjU2Iiwia3R5IjoiRUMiLCJ4IjoiNEhOcHRJLXhyMnBqeVJKS0dNbno0V21kblFEX3VKU3E0Ujk1Tmo5OGI0NCIsInkiOiJMSVpuU0IzOXZGSmhZZ1MzazdqWEU0cjMtQ29HRlF3WnRQQklScXBObHJnIiwia2lkIjoidmJlWEprc000NXhwaHRBTm5DaUc2bUN5dVU0amZHTnpvcEd1S3ZvZ2c5YyJ9fSwiYXV0aG9yaXphdGlvbl9lbmRwb2ludCI6ImV1ZGl3OiIsInJlc3BvbnNlX3R5cGVzX3N1cHBvcnRlZCI6WyJ2cF90b2tlbiJdLCJ2cF9mb3JtYXRzX3N1cHBvcnRlZCI6eyJqd3RfdnBfanNvbiI6eyJhbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFUzI1NiJdfSwiand0X3ZjX2pzb24iOnsiYWxnX3ZhbHVlc19zdXBwb3J0ZWQiOlsiRVMyNTYiXX19LCJyZXF1ZXN0X29iamVjdF9zaWduaW5nX2FsZ192YWx1ZXNfc3VwcG9ydGVkIjpbIkVTMjU2Il0sInByZXNlbnRhdGlvbl9kZWZpbml0aW9uX3VyaV9zdXBwb3J0ZWQiOmZhbHNlLCJpYXQiOjE2ODcyODExOTUsImV4cCI6MTY4NzI4ODM5NX0.OTuPik6p3o9j6VOx-uCyxRvHwoh1pDiiZcBQFNQt2uE3dK-8izGNflJVETi_uhGSZOf25Enkq-UvEin9NrbJNw";
+  "eyJhbGciOiJFUzI1NiIsImtpZCI6IjV0NVlZcEJoTi1FZ0lFRUk1aVV6cjZyME1SMDJMblZRME9tZWttTktjalkiLCJ0cnVzdF9jaGFpbiI6WyJleUpoYkdjaU9pSkZVei4uLjZTMEEiLCJleUpoYkdjaU9pSkZVei4uLmpKTEEiLCJleUpoYkdjaU9pSkZVei4uLkg5Z3ciXSwidHlwIjoid2FsbGV0LWF0dGVzdGF0aW9uK2p3dCIsIng1YyI6WyJNSUlCakRDQyAuLi4gWEZlaGdLUUE9PSJdfQ.eyJpc3MiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZyIsInN1YiI6InZiZVhKa3NNNDV4cGh0QU5uQ2lHNm1DeXVVNGpmR056b3BHdUt2b2dnOWMiLCJhdHRlc3RlZF9zZWN1cml0eV9jb250ZXh0IjoiaHR0cHM6Ly93YWxsZXQtcHJvdmlkZXIuZXhhbXBsZS5vcmcvTG9BL2Jhc2ljIiwiY25mIjp7Imp3ayI6eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6IjRITnB0SS14cjJwanlSSktHTW56NFdtZG5RRF91SlNxNFI5NU5qOThiNDQiLCJ5IjoiTElablNCMzl2RkpoWWdTM2s3alhFNHIzLUNvR0ZRd1p0UEJJUnFwTmxyZyIsImtpZCI6InZiZVhKa3NNNDV4cGh0QU5uQ2lHNm1DeXVVNGpmR056b3BHdUt2b2dnOWMifX0sImF1dGhvcml6YXRpb25fZW5kcG9pbnQiOiJldWRpdzoiLCJyZXNwb25zZV90eXBlc19zdXBwb3J0ZWQiOlsidnBfdG9rZW4iXSwidnBfZm9ybWF0c19zdXBwb3J0ZWQiOnsiand0X3ZwX2pzb24iOnsiYWxnX3ZhbHVlc19zdXBwb3J0ZWQiOlsiRVMyNTYiXX0sImp3dF92Y19qc29uIjp7ImFsZ192YWx1ZXNfc3VwcG9ydGVkIjpbIkVTMjU2Il19fSwicmVxdWVzdF9vYmplY3Rfc2lnbmluZ19hbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFUzI1NiJdLCJwcmVzZW50YXRpb25fZGVmaW5pdGlvbl91cmlfc3VwcG9ydGVkIjpmYWxzZSwiaWF0IjoxNjk0NTk3NDM3LCJleHAiOjE2OTQ2MDQ2Mzd9.kg3llifa04avKP4t8uz-9ng2ODo1SX8KoXVQpoGIlcJThlEw40tp4NRUiW_iJvGd3fZD8eIbQ3tdrXKlJSXZRQ";
 
 describe("decode", () => {
   it("should return Wallet Instance Attestation", async () => {
@@ -20,7 +20,7 @@ describe("decode", () => {
         "eyJhbGciOiJFUz...jJLA",
         "eyJhbGciOiJFUz...H9gw",
       ],
-      typ: "va+jwt",
+      typ: "wallet-attestation+jwt",
       x5c: ["MIIBjDCC ... XFehgKQA=="],
     });
 
@@ -28,11 +28,8 @@ describe("decode", () => {
     expect(result.payload).toEqual({
       iss: "https://wallet-provider.example.org",
       sub: "vbeXJksM45xphtANnCiG6mCyuU4jfGNzopGuKvogg9c",
-      type: "WalletInstanceAttestation",
-      policy_uri: "https://wallet-provider.example.org/privacy_policy",
-      tos_uri: "https://wallet-provider.example.org/info_policy",
-      logo_uri: "https://wallet-provider.example.org/logo.svg",
-      asc: "https://wallet-provider.example.org/LoA/basic",
+      attested_security_context:
+        "https://wallet-provider.example.org/LoA/basic",
       cnf: {
         jwk: {
           crv: "P-256",
@@ -54,8 +51,8 @@ describe("decode", () => {
       },
       request_object_signing_alg_values_supported: ["ES256"],
       presentation_definition_uri_supported: false,
-      iat: 1687281195,
-      exp: 1687288395,
+      iat: 1694597437,
+      exp: 1694604637,
     });
   });
 });

--- a/src/wallet-instance-attestation/issuing.ts
+++ b/src/wallet-instance-attestation/issuing.ts
@@ -34,9 +34,9 @@ export class Issuing {
 
     const walletInstanceAttestationRequest = new SignJWT({
       iss: keyThumbprint,
-      sub: this.walletProviderBaseUrl,
+      aud: this.walletProviderBaseUrl,
       jti: `${uuid.v4()}`,
-      type: "WalletInstanceAttestationRequest",
+      nonce: `${uuid.v4()}`,
       cnf: {
         jwk: fixBase64EncodingOnKey(publicKey),
       },
@@ -44,7 +44,7 @@ export class Issuing {
       .setProtectedHeader({
         alg: "ES256",
         kid: publicKey.kid,
-        typ: "var+jwt",
+        typ: "wiar+jwt",
       })
       .setIssuedAt()
       .setExpirationTime("1h")
@@ -87,7 +87,7 @@ export class Issuing {
     const tokenUrl = new URL("token", this.walletProviderBaseUrl).href;
     const requestBody = {
       grant_type:
-        "urn:ietf:params:oauth:client-assertion-type:jwt-key-attestation",
+        "urn:ietf:params:oauth:client-assertion-type:jwt-client-attestation",
       assertion: signedAttestationRequest,
     };
     const response = await this.appFetch(tokenUrl, {

--- a/src/wallet-instance-attestation/types.ts
+++ b/src/wallet-instance-attestation/types.ts
@@ -14,7 +14,6 @@ const Jwt = z.object({
   }),
   payload: z.object({
     iss: z.string(),
-    sub: z.string(),
     iat: UnixTime,
     exp: UnixTime,
     cnf: z.object({
@@ -34,14 +33,15 @@ export const WalletInstanceAttestationRequestJwt = z.object({
   header: z.intersection(
     Jwt.shape.header,
     z.object({
-      typ: z.literal("var+jwt"),
+      typ: z.literal("wiar+jwt"),
     })
   ),
   payload: z.intersection(
     Jwt.shape.payload,
     z.object({
+      aud: z.string(),
       jti: z.string(),
-      type: z.literal("WalletInstanceAttestationRequest"),
+      nonce: z.string(),
     })
   ),
 });
@@ -53,17 +53,14 @@ export const WalletInstanceAttestationJwt = z.object({
   header: z.intersection(
     Jwt.shape.header,
     z.object({
-      typ: z.literal("va+jwt"),
+      typ: z.literal("wallet-attestation+jwt"),
     })
   ),
   payload: z.intersection(
     Jwt.shape.payload,
     z.object({
-      type: z.literal("WalletInstanceAttestation"),
-      policy_uri: z.string().url(),
-      tos_uri: z.string().url(),
-      logo_uri: z.string().url(),
-      asc: z.string(),
+      sub: z.string(),
+      attested_security_context: z.string(),
       authorization_endpoint: z.string(),
       response_types_supported: z.array(z.string()),
       vp_formats_supported: z.object({


### PR DESCRIPTION
Aligns obtaining the `Wallet Instance Attestation` with technical rules `0.5.0`.  
#### List of Changes

For the `Wallet Instance Attestation Request`:
- changed `typ` value from `var+jwt` to `wiar+jwt` 
- replaced the `sub` parameter with `aud`
- removed the `type` parameter 
- added the `nonce`  parameter

For the `Wallet Instance Attestation`:
- removed the `type` parameter
- removed the `policy_uri` parameter
- removed the `tos_uri` parameter
- removed the `logo_uri` parameter
- replaced the `asc` parameter with `attested_security_context`

For the HTTP request:
- Changed the grant_type value from `urn:ietf:params:oauth:client-assertion-type:jwt-key-attestation` to `urn:ietf:params:oauth:client-assertion-type:jwt-client-attestation`


#### How Has This Been Tested?
Unit tested and locally

#### Checklist:
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
