### PR TITLE
Fix #34 Entity Configuration parsing

### DIFF
--- a/example/src/scenarios/cross-device-flow-with-rp.tsx
+++ b/example/src/scenarios/cross-device-flow-with-rp.tsx
@@ -1,14 +1,14 @@
 import { sign, generate, getPublicKey } from "@pagopa/io-react-native-crypto";
-import { RelyingPartySolution } from "@pagopa/io-react-native-wallet";
 import {
   WalletInstanceAttestation,
   getEntityConfiguration,
   verifyTrustChain,
+  RelyingPartySolution,
+  TrustAnchorEntityConfiguration,
 } from "@pagopa/io-react-native-wallet";
 import { error, result } from "./types";
 import { SignJWT } from "@pagopa/io-react-native-jwt";
 import getPid from "./get-pid";
-import { TrustAnchorEntityConfiguration } from "src/trust/types";
 
 const QR =
   "aHR0cHM6Ly9kZW1vLnByb3h5LmV1ZGkud2FsbGV0LmRldmVsb3BlcnMuaXRhbGlhLml0L09wZW5JRDRWUD9jbGllbnRfaWQ9aHR0cHMlM0ElMkYlMkZkZW1vLnByb3h5LmV1ZGkud2FsbGV0LmRldmVsb3BlcnMuaXRhbGlhLml0JTJGT3BlbklENFZQJnJlcXVlc3RfdXJpPWh0dHBzJTNBJTJGJTJGZGVtby5wcm94eS5ldWRpLndhbGxldC5kZXZlbG9wZXJzLml0YWxpYS5pdCUyRk9wZW5JRDRWUCUyRnJlcXVlc3QtdXJpJTNGaWQlM0RkZDA3NzBhMC05ZTM1LTQ3OTUtYjZlYi03MDlkZDg1ZDM1ODM=";
@@ -93,7 +93,8 @@ export default async () => {
     ).then((t) => RP.getRequestObject(t, authRequestUrl, entity));
 
     // Attest Relying Party trust
-    await verifyTrustChain(trustAnchorEntity, requestObj.header.trust_chain);
+    // FIXME: [SIW-489] Request Object is coming with an empty trust chain, comment for now
+    // await verifyTrustChain(trustAnchorEntity, requestObj.header.trust_chain);
 
     // select claims to be disclose from pid
     // these would be selected by users in the UI

--- a/example/src/scenarios/cross-device-flow-with-rp.tsx
+++ b/example/src/scenarios/cross-device-flow-with-rp.tsx
@@ -1,22 +1,16 @@
 import { sign, generate, getPublicKey } from "@pagopa/io-react-native-crypto";
 import {
   WalletInstanceAttestation,
-  getEntityConfiguration,
-  verifyTrustChain,
   RelyingPartySolution,
-  TrustAnchorEntityConfiguration,
 } from "@pagopa/io-react-native-wallet";
 import { error, result } from "./types";
 import { SignJWT } from "@pagopa/io-react-native-jwt";
 import getPid from "./get-pid";
 
 const QR =
-  "aHR0cHM6Ly9kZW1vLnByb3h5LmV1ZGkud2FsbGV0LmRldmVsb3BlcnMuaXRhbGlhLml0L09wZW5JRDRWUD9jbGllbnRfaWQ9aHR0cHMlM0ElMkYlMkZkZW1vLnByb3h5LmV1ZGkud2FsbGV0LmRldmVsb3BlcnMuaXRhbGlhLml0JTJGT3BlbklENFZQJnJlcXVlc3RfdXJpPWh0dHBzJTNBJTJGJTJGZGVtby5wcm94eS5ldWRpLndhbGxldC5kZXZlbG9wZXJzLml0YWxpYS5pdCUyRk9wZW5JRDRWUCUyRnJlcXVlc3QtdXJpJTNGaWQlM0RkZDA3NzBhMC05ZTM1LTQ3OTUtYjZlYi03MDlkZDg1ZDM1ODM=";
+  "aHR0cHM6Ly9kZW1vLnByb3h5LmV1ZGkud2FsbGV0LmRldmVsb3BlcnMuaXRhbGlhLml0L09wZW5JRDRWUD9jbGllbnRfaWQ9aHR0cHMlM0ElMkYlMkZkZW1vLnByb3h5LmV1ZGkud2FsbGV0LmRldmVsb3BlcnMuaXRhbGlhLml0JTJGT3BlbklENFZQJnJlcXVlc3RfdXJpPWh0dHBzJTNBJTJGJTJGZGVtby5wcm94eS5ldWRpLndhbGxldC5kZXZlbG9wZXJzLml0YWxpYS5pdCUyRk9wZW5JRDRWUCUyRnJlcXVlc3QtdXJpJTNGaWQlM0Q1MzAyYWExNC1iMTZlLTRmNjItYTdkYS0wZmFiMDM0ZGE2ODI=";
 
 const walletInstanceKeyTag = Math.random().toString(36).substr(2, 5);
-
-const trustAnchorBaseUrl =
-  "https://demo.federation.eudi.wallet.developers.italia.it/";
 
 async function getAttestation(): Promise<{
   attestation: string;
@@ -52,11 +46,6 @@ async function getAttestation(): Promise<{
 
 export default async () => {
   try {
-    // trust anchor entity could be already fetched at application start
-    const trustAnchorEntity = await getEntityConfiguration(
-      trustAnchorBaseUrl
-    ).then(TrustAnchorEntityConfiguration.parse);
-
     // obtain new attestation
     const WIA = await getAttestation();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-wallet",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Provide data structures, helpers and API for IO Wallet",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,13 @@ import * as Errors from "./utils/errors";
 import * as WalletInstanceAttestation from "./wallet-instance-attestation";
 import { getUnsignedDPop } from "./utils/dpop";
 import { RelyingPartySolution } from "./rp";
+import { RpEntityConfiguration } from "./rp/types";
 import { verifyTrustChain, getEntityConfiguration } from "./trust";
+import {
+  EntityConfiguration,
+  EntityStatement,
+  TrustAnchorEntityConfiguration,
+} from "./trust/types";
 
 export {
   PID,
@@ -19,4 +25,8 @@ export {
   RelyingPartySolution,
   verifyTrustChain,
   getEntityConfiguration,
+  EntityConfiguration,
+  EntityStatement,
+  RpEntityConfiguration,
+  TrustAnchorEntityConfiguration,
 };

--- a/src/rp/types.ts
+++ b/src/rp/types.ts
@@ -35,13 +35,15 @@ export const RpEntityConfiguration = EntityConfiguration.and(
   z.object({
     payload: z.object({
       metadata: z.object({
-        wallet_relying_party: z.object({
-          application_type: z.string(),
-          client_id: z.string(),
-          client_name: z.string(),
-          jwks: z.array(JWK),
-          contacts: z.array(z.string()),
-        }),
+        wallet_relying_party: z
+          .object({
+            application_type: z.string().optional(),
+            client_id: z.string().optional(),
+            client_name: z.string().optional(),
+            jwks: z.array(JWK),
+            contacts: z.array(z.string()).optional(),
+          })
+          .passthrough(),
       }),
     }),
   })

--- a/src/trust/__tests__/index.test.ts
+++ b/src/trust/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import { EntityConfiguration } from "../types";
 import { verifyTrustChain } from "..";
 import {
   intermediateEntityStatement,
@@ -105,5 +106,26 @@ describe("verifyTrustChain", () => {
         await signed(intermediateEntityStatement),
       ])
     ).rejects.toThrow();
+  });
+});
+
+describe("EntityConfiguration", () => {
+  it("should not strip unknwon metadata fields", () => {
+    const withAdditionalField = {
+      header: leafEntityConfiguration.header,
+      payload: {
+        ...leafEntityConfiguration.payload,
+        metadata: {
+          ...leafEntityConfiguration.payload.metadata,
+          additional_field: "foo",
+        },
+      },
+    };
+
+    const parsed = EntityConfiguration.parse(withAdditionalField);
+
+    expect(parsed.payload.metadata.additional_field).toEqual(
+      withAdditionalField.payload.metadata.additional_field
+    );
   });
 });

--- a/src/trust/types.ts
+++ b/src/trust/types.ts
@@ -37,16 +37,24 @@ export const EntityConfiguration = z.object({
     jwks: z.object({
       keys: z.array(JWK),
     }),
-    metadata: z.object({
-      federation_entity: z.object({
-        organization_name: z.string(),
-        homepage_uri: z.string(),
-        policy_uri: z.string(),
-        logo_uri: z.string(),
-        contacts: z.array(z.string()),
-      }),
-    }),
-    authority_hints: z.array(z.string()),
+    metadata: z
+      .object({
+        federation_entity: z
+          .object({
+            federation_fetch_endpoint: z.string().optional(),
+            federation_list_endpoint: z.string().optional(),
+            federation_resolve_endpoint: z.string().optional(),
+            federation_trust_mark_status_endpoint: z.string().optional(),
+            federation_trust_mark_list_endpoint: z.string().optional(),
+            homepage_uri: z.string().optional(),
+            policy_uri: z.string().optional(),
+            logo_uri: z.string().optional(),
+            contacts: z.array(z.string()).optional(),
+          })
+          .passthrough(),
+      })
+      .passthrough(),
+    authority_hints: z.array(z.string()).optional(),
   }),
 });
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* fix `EntityConfiguration` and `RpEntityConfiguration` parsers so they don't strip unknown keys
* set `federation_entity` attributes as optional, according to https://openid.net/specs/openid-connect-federation-1_0.html#appendix-A.2.2-5
* skip trust chain verification as it's not resolved yet by the test Relying Party
* expose `EntityConfiguration`, `TrustAnchorEntityConfiguration` and `RpEntityConfiguration` types

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Bugs were introduced in https://github.com/pagopa/io-react-native-wallet/pull/34 as the entity configurations failed to be parsed. This is due to a misinterpreted feature of `zod` that [automatically strips additional fields on objects](https://github.com/colinhacks/zod/tree/v2#migration-from-v1).


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Example app

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
