### PR TITLE
build: [SIW-494] Remove old example xcworkspace

### DIFF
--- a/example/ios/example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/example/ios/example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
This pull request eliminates the outdated example xcworkspace which is no longer needed.
<!--- Describe your changes in detail -->

#### Motivation and Context
When attempting to execute `yarn ios` on the example app, React Native throws an error due to the obsolete xcworkspace, resulting in a failure to locate a project with that particular name. This problem arises as a consequence of the refactoring carried out in pull request #36. However, by removing the outdated xcworkspace, React Native will correctly interpret the xcworkspace with the updated name, `IoReactNativeWalletExample.xcworkspace`.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Run `yarn ios` and the example app should now build without throwing an error.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
