### PR TITLE
feat: [SIW-559] Add deep link handler for cross device scenario in example App

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" android:host="*" />
+        </intent>
+    </queries>
     <uses-permission android:name="android.permission.INTERNET" />
-
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"
@@ -20,6 +24,12 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
+        <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <data android:scheme="eudiw" />
+      </intent-filter>
       </activity>
     </application>
 </manifest>

--- a/example/ios/IoReactNativeWalletExample/AppDelegate.mm
+++ b/example/ios/IoReactNativeWalletExample/AppDelegate.mm
@@ -1,8 +1,20 @@
 #import "AppDelegate.h"
 
 #import <React/RCTBundleURLProvider.h>
+#import <React/RCTLinkingManager.h>
+
 
 @implementation AppDelegate
+
+
+// For deep link handler
+- (BOOL)application:(UIApplication *)application
+   openURL:(NSURL *)url
+   options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
+
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {

--- a/example/ios/IoReactNativeWalletExample/Info.plist
+++ b/example/ios/IoReactNativeWalletExample/Info.plist
@@ -20,6 +20,19 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>eudiw</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>eudiw</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -78,7 +78,7 @@ PODS:
   - OpenSSL-Universal (1.1.1100)
   - pagopa-io-react-native-crypto (0.2.3):
     - React-Core
-  - pagopa-io-react-native-jwt (0.6.4):
+  - pagopa-io-react-native-jwt (1.0.0):
     - JOSESwift (~> 2.3)
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
@@ -688,7 +688,7 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   pagopa-io-react-native-crypto: 93f984df8711eb72f3fb030eca51be6268fc96d6
-  pagopa-io-react-native-jwt: 77009ad67f428b5b948442dbe1e5d8aa7fb3538e
+  pagopa-io-react-native-jwt: 637df21a8a7839c70e52c4a7614a04cca7335fb3
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: c0569ecc035894e4a68baecb30fe6a7ea6e399f9
   RCTTypeSafety: e90354072c21236e0bcf1699011e39acd25fea2f

--- a/example/package.json
+++ b/example/package.json
@@ -21,6 +21,7 @@
     "@react-native/eslint-config": "^0.72.2",
     "@react-native/metro-config": "^0.72.11",
     "babel-plugin-module-resolver": "^5.0.0",
-    "metro-react-native-babel-preset": "0.76.8"
+    "metro-react-native-babel-preset": "0.76.8",
+    "react-native-url-polyfill": "^2.0.0"
   }
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,8 +1,39 @@
-import * as React from "react";
-import { StyleSheet, View, Text, Button, SafeAreaView } from "react-native";
+import {
+  StyleSheet,
+  View,
+  Text,
+  Button,
+  SafeAreaView,
+  Linking,
+} from "react-native";
 import scenarios, { type ScenarioRunner } from "./scenarios";
+import React, { useEffect } from "react";
+import "react-native-url-polyfill/auto";
+import { encodeBase64 } from "@pagopa/io-react-native-jwt";
 
 export default function App() {
+  const [deeplink, setDeeplink] = React.useState<string | undefined>();
+
+  useEffect(() => {
+    Linking.getInitialURL()
+      .then((url) => {
+        if (url !== null) {
+          setDeeplink(url);
+        }
+      })
+      .catch((err) => console.error("An error occurred", err));
+    let subcribtion = Linking.addEventListener("url", handleOpenURL);
+    subcribtion.subscriber;
+    return () => {
+      subcribtion.remove();
+    };
+  });
+
+  function handleOpenURL(evt: { url: any }) {
+    // Will be called when the notification is pressed foreground
+    setDeeplink(evt.url);
+  }
+
   return (
     <SafeAreaView style={styles.container}>
       <TestScenario title="Decode PID" scenario={scenarios.decodePid} />
@@ -10,10 +41,7 @@ export default function App() {
       <TestScenario title="Get WIA" scenario={scenarios.getAttestation} />
       <TestScenario title="Get PID" scenario={scenarios.getPid} />
       <TestScenario title="Decode QR from RP" scenario={scenarios.decodeQR} />
-      <TestScenario
-        title="Cross-device flow with RP"
-        scenario={scenarios.crossDeviceFlowRP}
-      />
+      <TestCrossDeviceFlowScenarioWithDeepLink deeplink={deeplink} />
     </SafeAreaView>
   );
 }
@@ -45,6 +73,55 @@ function TestScenario({
   return (
     <View>
       <Button title={title} onPress={run(scenario)} />
+      <Text style={styles.title}>{result}</Text>
+    </View>
+  );
+}
+
+function TestCrossDeviceFlowScenarioWithDeepLink({
+  deeplink,
+}: {
+  deeplink: string | undefined;
+}) {
+  const [result, setResult] = React.useState<string | undefined>();
+  React.useEffect(() => {
+    if (deeplink) {
+      run(encodeBase64(deeplink));
+    } else {
+      setResult("READY");
+    }
+  }, [deeplink]);
+
+  async function run(qrCode: string) {
+    setResult("⏱️... authenticating to RP via deep link");
+    const [error, _result] = await scenarios.crossDeviceFlowRP(qrCode);
+    if (error) {
+      setResult(`❌ ${JSON.stringify(error)}`);
+    } else {
+      setResult("✅");
+    }
+  }
+
+  const openBrowser = (url: string) => {
+    Linking.canOpenURL(url).then((supported) => {
+      if (supported) {
+        Linking.openURL(url);
+      } else {
+        console.log("Error during url opening: " + url);
+      }
+    });
+  };
+
+  return (
+    <View>
+      <Button
+        title={"Cross device flow with deep link handler"}
+        onPress={() => {
+          openBrowser(
+            "https://demo.rp.eudi.wallet.developers.italia.it/saml2/login/"
+          );
+        }}
+      />
       <Text style={styles.title}>{result}</Text>
     </View>
   );

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -22,8 +22,9 @@ export default function App() {
         }
       })
       .catch((err) => console.error("An error occurred", err));
+
     let subcribtion = Linking.addEventListener("url", handleOpenURL);
-    subcribtion.subscriber;
+
     return () => {
       subcribtion.remove();
     };

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -41,7 +41,7 @@ export default function App() {
       <TestScenario title="Get WIA" scenario={scenarios.getAttestation} />
       <TestScenario title="Get PID" scenario={scenarios.getPid} />
       <TestScenario title="Decode QR from RP" scenario={scenarios.decodeQR} />
-      <TestCrossDeviceFlowScenarioWithDeepLink deeplink={deeplink} />
+      <TestSameDeviceFlowScenarioWithDeepLink deeplink={deeplink} />
     </SafeAreaView>
   );
 }
@@ -78,7 +78,7 @@ function TestScenario({
   );
 }
 
-function TestCrossDeviceFlowScenarioWithDeepLink({
+function TestSameDeviceFlowScenarioWithDeepLink({
   deeplink,
 }: {
   deeplink: string | undefined;
@@ -94,7 +94,7 @@ function TestCrossDeviceFlowScenarioWithDeepLink({
 
   async function run(qrCode: string) {
     setResult("⏱️... authenticating to RP via deep link");
-    const [error, _result] = await scenarios.crossDeviceFlowRP(qrCode);
+    const [error, _result] = await scenarios.authenticationToRP(qrCode);
     if (error) {
       setResult(`❌ ${JSON.stringify(error)}`);
     } else {
@@ -115,7 +115,7 @@ function TestCrossDeviceFlowScenarioWithDeepLink({
   return (
     <View>
       <Button
-        title={"Cross device flow with deep link handler"}
+        title={"Same device flow with deep link handler"}
         onPress={() => {
           openBrowser(
             "https://demo.rp.eudi.wallet.developers.italia.it/saml2/login/"

--- a/example/src/scenarios/cross-device-flow-with-rp.tsx
+++ b/example/src/scenarios/cross-device-flow-with-rp.tsx
@@ -7,10 +7,9 @@ import { error, result, toResultOrReject } from "./types";
 import getPid from "./get-pid";
 import getWalletInstanceAttestation from "./get-attestation";
 
-const QR =
-  "aHR0cHM6Ly9kZW1vLnByb3h5LmV1ZGkud2FsbGV0LmRldmVsb3BlcnMuaXRhbGlhLml0L09wZW5JRDRWUD9jbGllbnRfaWQ9aHR0cHMlM0ElMkYlMkZkZW1vLnByb3h5LmV1ZGkud2FsbGV0LmRldmVsb3BlcnMuaXRhbGlhLml0JTJGT3BlbklENFZQJnJlcXVlc3RfdXJpPWh0dHBzJTNBJTJGJTJGZGVtby5wcm94eS5ldWRpLndhbGxldC5kZXZlbG9wZXJzLml0YWxpYS5pdCUyRk9wZW5JRDRWUCUyRnJlcXVlc3QtdXJpJTNGaWQlM0Q1MzAyYWExNC1iMTZlLTRmNjItYTdkYS0wZmFiMDM0ZGE2ODI=";
-
-export default async () => {
+export default async (
+  qr = "aHR0cHM6Ly9kZW1vLnByb3h5LmV1ZGkud2FsbGV0LmRldmVsb3BlcnMuaXRhbGlhLml0L09wZW5JRDRWUD9jbGllbnRfaWQ9aHR0cHMlM0ElMkYlMkZkZW1vLnByb3h5LmV1ZGkud2FsbGV0LmRldmVsb3BlcnMuaXRhbGlhLml0JTJGT3BlbklENFZQJnJlcXVlc3RfdXJpPWh0dHBzJTNBJTJGJTJGZGVtby5wcm94eS5ldWRpLndhbGxldC5kZXZlbG9wZXJzLml0YWxpYS5pdCUyRk9wZW5JRDRWUCUyRnJlcXVlc3QtdXJpJTNGaWQlM0RkMmMyYzRhYi1lM2I4LTRjNTAtYTRlYy1lNjY4ZTgxNzVlNWY="
+) => {
   try {
     const walletInstanceKeyTag = Math.random().toString(36).substr(2, 5);
     // obtain new attestation
@@ -26,7 +25,7 @@ export default async () => {
 
     // Scan/Decode QR
     const { requestURI: authRequestUrl, clientId } =
-      RelyingPartySolution.decodeAuthRequestQR(QR);
+      RelyingPartySolution.decodeAuthRequestQR(qr);
 
     // resolve RP's entity configuration
     const entityConfiguration = await getRelyingPartyEntityConfiguration(

--- a/example/src/scenarios/index.tsx
+++ b/example/src/scenarios/index.tsx
@@ -3,7 +3,7 @@ import getAttestation from "./get-attestation";
 import verifyPid from "./verify-pid";
 import decodePid from "./decode-pid";
 import decodeQR from "./decode-qr-from-rp";
-import crossDeviceFlowRP from "./cross-device-flow-with-rp";
+import authenticationToRP from "./cross-device-flow-with-rp";
 
 const scenarios = {
   getPid,
@@ -11,7 +11,7 @@ const scenarios = {
   verifyPid,
   decodePid,
   decodeQR,
-  crossDeviceFlowRP,
+  authenticationToRP,
 };
 
 export default scenarios;

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2078,7 +2078,7 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-buffer@^5.5.0:
+buffer@^5.4.3, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -4643,6 +4643,11 @@ prop-types@*, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+punycode@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
+  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -4682,6 +4687,13 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-native-url-polyfill@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz#db714520a2985cff1d50ab2e66279b9f91ffd589"
+  integrity sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==
+  dependencies:
+    whatwg-url-without-unicode "8.0.0-3"
 
 react-native@0.72.4:
   version "0.72.4"
@@ -5484,10 +5496,24 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
+webidl-conversions@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
+  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
+
 whatwg-fetch@^3.0.0:
   version "3.6.18"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.18.tgz#2f640cdee315abced7daeaed2309abd1e44e62d4"
   integrity sha512-ltN7j66EneWn5TFDO4L9inYC1D+Czsxlrw2SalgjMmEMkLfA5SIZxEFdE6QtHFiiM6Q7WL32c7AkI3w6yxM84Q==
+
+whatwg-url-without-unicode@8.0.0-3:
+  version "8.0.0-3"
+  resolved "https://registry.yarnpkg.com/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz#ab6df4bf6caaa6c85a59f6e82c026151d4bb376b"
+  integrity sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==
+  dependencies:
+    buffer "^5.4.3"
+    punycode "^2.1.1"
+    webidl-conversions "^5.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Adds integration to the `eudiw://` deeplink to test the same device authentication scenario towards RP.
⚠️ Warning: Only for the example app a deep link (eudiw://) was used but for future versions a universal link will be used as decided within the RFC.

#### List of Changes
- Added handler for `eudiw://` deep link which automatically starts the authentication flow towards RP.

#### Motivation and Context
This PR was necessary as it is no longer possible to use dated **QR Codes** (therefore hard coded in the app) as they are expired but a fresh session must be used. The implementation of the **same device flow** allows you to avoid using the camera on the simulator to obtain the content of the QR Code.

#### How Has This Been Tested?
Tested on real devices and simulators on iOS and Android

#### Screenshots (if appropriate):

https://github.com/pagopa/io-react-native-wallet/assets/442709/8cd1c17c-fe4a-4985-bdb9-4311c32db1eb



#### Checklist:


- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
