### PR TITLE
fix: [SIW-540] Restore exported types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-wallet",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Provide data structures, helpers and API for IO Wallet",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,12 @@ import {
   getTrustAnchorEntityConfiguration,
   getWalletProviderEntityConfiguration,
 } from "./trust";
+import {
+  RelyingPartyEntityConfiguration,
+  WalletProviderEntityConfiguration,
+  TrustAnchorEntityConfiguration,
+  CredentialIssuerEntityConfiguration,
+} from "./trust/types";
 import { createCryptoContextFor } from "./utils/crypto";
 
 export {
@@ -30,4 +36,8 @@ export {
   getTrustAnchorEntityConfiguration,
   getWalletProviderEntityConfiguration,
   createCryptoContextFor,
+  RelyingPartyEntityConfiguration,
+  WalletProviderEntityConfiguration,
+  TrustAnchorEntityConfiguration,
+  CredentialIssuerEntityConfiguration,
 };


### PR DESCRIPTION
In https://github.com/pagopa/io-react-native-wallet/pull/43 we decided to not expose entity configuration types, as they might be inferred. In https://github.com/pagopa/io-app/pull/5039#discussion_r1340274555 it comes up they are useful, so in this PR we make them available again.