### PR TITLE
feat!: [SIW-545] Adds the authorization endpoint for PID issuing

### DIFF
--- a/example/src/scenarios/get-pid.tsx
+++ b/example/src/scenarios/get-pid.tsx
@@ -30,7 +30,13 @@ export default async (pidKeyTag = Math.random().toString(36).substr(2, 5)) => {
     const authConf = await authRequest(
       instanceAttestation,
       walletProviderBaseUrl,
-      pidEntityConfiguration
+      pidEntityConfiguration,
+      {
+        birthDate: "01/01/1990",
+        fiscalCode: "AAABBB00A00A000A",
+        name: "NAME",
+        surname: "SURNAME",
+      }
     );
 
     // Generate fresh key for PID binding
@@ -40,12 +46,7 @@ export default async (pidKeyTag = Math.random().toString(36).substr(2, 5)) => {
 
     // Credential request
     const credentialRequest = PID.Issuing.getCredential({ pidCryptoContext });
-    const pid = await credentialRequest(authConf, pidEntityConfiguration, {
-      birthDate: "01/01/1990",
-      fiscalCode: "AAABBB00A00A000A",
-      name: "NAME",
-      surname: "SURNAME",
-    });
+    const pid = await credentialRequest(authConf, pidEntityConfiguration);
 
     // throw if decode fails
     PID.SdJwt.decode(pid.credential);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-wallet",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Provide data structures, helpers and API for IO Wallet",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/pid/issuing.ts
+++ b/src/pid/issuing.ts
@@ -164,6 +164,11 @@ const getAuthenticationRequest =
       pidProviderEntityConfiguration.payload.metadata.openid_credential_issuer
         .authorization_endpoint;
 
+    /* User's personal data is not supposed to transit in this flow,
+     * but to be provided to the PID issuer directly by its chosen authentication method (CIE).
+     * Being the project in an initial phase, and being we were still unable to fully comply with authentication,
+     * we temporarily provide data from the App's logged user.
+     * */
     const params = new URLSearchParams({
       client_id: clientId,
       request_uri: requestUri,

--- a/src/pid/issuing.ts
+++ b/src/pid/issuing.ts
@@ -195,8 +195,9 @@ const getAuthenticationRequest =
  * @param params.wiaCryptoContext The key pair associated with the WIA. Will be use to prove the ownership of the attestation.
  * @param params.appFetch (optional) Http client
  * @param walletInstanceAttestation Wallet Instance Attestation token.
- * @param walletProviderBaseUrl Base url for the Wallet Provider
+ * @param walletProviderBaseUrl Base url for the Wallet Provider.
  * @param pidProviderEntityConfiguration The Entity Configuration of the PID Provider, from which discover public endooints.
+ * @param cieData Data red from the CIE login process
  * @returns The access token along with the values that identify the issuing session.
  */
 export const authorizeIssuing =
@@ -321,7 +322,6 @@ const createNonceProof = async (
  * @param params.pidCryptoContext The key pair associated with the PID. Will be use to prove the ownership of the credential.
  * @param params.appFetch (optional) Http client
  * @param authConf The authorization configuration retrieved with the access token
- * @param cieData Data red from the CIE login process
  * @returns The PID credential token
  */
 export const getCredential =

--- a/src/pid/issuing.ts
+++ b/src/pid/issuing.ts
@@ -12,11 +12,7 @@ import { CredentialIssuerEntityConfiguration } from "../trust/types";
 import * as WalletInstanceAttestation from "../wallet-instance-attestation";
 import { generate, deleteKey } from "@pagopa/io-react-native-crypto";
 import { SdJwt } from ".";
-<<<<<<< Updated upstream
 import { createCryptoContextFor } from "../utils/crypto";
-=======
-
->>>>>>> Stashed changes
 // This is a temporary type that will be used for demo purposes only
 export type CieData = {
   birthDate: string;
@@ -147,7 +143,7 @@ const getAuthenticationRequest =
   async (
     clientId: string,
     requestUri: string,
-    pidProviderEntityConfiguration: PidIssuerEntityConfiguration
+    pidProviderEntityConfiguration: CredentialIssuerEntityConfiguration
   ): Promise<string> => {
     const authzRequestEndpoint =
       pidProviderEntityConfiguration.payload.metadata.openid_credential_issuer
@@ -213,15 +209,16 @@ export const authorizeIssuing =
       pidProviderEntityConfiguration,
       walletInstanceAttestation
     );
+
     /*
-    const authzRequest = await getAuthenticationRequest({ appFetch })(
+    const authenticationRequest = await getAuthenticationRequest({})(
       clientId,
       requestUri,
       pidProviderEntityConfiguration
     );
-
-    console.log("authzRequest", authzRequest);
+    console.log(authenticationRequest);
     */
+
     // Use an ephemeral key to be destroyed after use
     const keytag = `ephemeral-${uuid.v4()}`;
     await generate(keytag);

--- a/src/utils/__tests__/decoder.test.ts
+++ b/src/utils/__tests__/decoder.test.ts
@@ -1,29 +1,25 @@
 import { getJwtFromFormPost } from "../decoder";
 import { ValidationFailed } from "../errors";
 
-const fakeFormPost = `<html>
- <head><title>Submit This Form</title></head>
- <body onload="javascript:document.forms[0].submit()">
-  <form method="post" action="https://client.example.com/cb">
-    <input type="hidden" name="response"
-     value="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2
-      FjY291bnRzLmV4YW1wbGUuY29tIiwiYXVkIjoiczZCaGRSa3F0MyIsImV4cCI6MTM
-      xMTI4MTk3MCwiYWNjZXNzX3Rva2VuIjoiMllvdG5GWkZFanIxekNzaWNNV3BBQSIs
-      InN0YXRlIjoiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2SDlqc1luaTlkT
-      UFKdyIsInRva2VuX3R5cGUiOiJiZWFyZXIiLCJleHBpcmVzX2luIjoiMzYwMCIsIn
-      Njb3BlIjoiZXhhbXBsZSJ9.bgHLOu2dlDjtCnvTLK7hTN_JNwoZXEBnbXQx5vd9z1
-      7v1HyzfMqz00Vi002T-SWf2JEs3IVSvAe1xWLIY0TeuaiegklJx_gvB59SQIhXX2i
-      fzRmqPoDdmJGaWZ3tnRyFWNnEogJDqGFCo2RHtk8fXkE5IEiBD0g-tN0GS_XnxlE"/>
-    </form>
+const fakeFormPost = `<html xmlns:tiles="http://www.thymeleaf.org">
+	<head>
+		<title tiles:fragment="title">Submit This Form</title>
+		<meta charset="utf-8">
+	</head>
+	<body onload="javascript:document.forms[0].submit()">
+	    <form method="post" name="action" value="/callback">
+	      <input type="hidden" name="response"
+	       value="eyJraWQiOiJlTk4tZzVpNkNuTEtjbHRRQnA2YWJiaW9HTWJ6TTZtdVczdnV4dzZ1aDg4IiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwaS5ldWRpLXdhbGxldC1pdC1waWQtcHJvdmlkZXIuaXQiLCJjb2RlIjoic1d6YlNWbC0wUlZ1WGkzclNSeUVQT3ZZM2k0cUZYTXkteV9HbFhyRVdZSSIsInN0YXRlIjoiYzQwZmRiMzctMmJmOC00ZjUzLTg4ZTUtNTY2ZjA5MGQxMjgzIn0.uZtN5FXNFgL-7D0U1ELLOLq_0a6MIg6BFHSVutolqnmJLYnbvlmONvNCTJ3kaWjy7mnNU41MbU4n0VH82-7rJ9ZBYA2Hr1nbgiHJTh38tXRnxjnyE7G1XYxxYEMSRV2Avm4ahSXUlo-tQnzbzFEm9_-2iFxoaVpUjU9crXxfGwRkvX_TAwS7zPeLBIEolLfgDc6ZRvNpmulbVVY_z4vVRlwIQg7N-cLN_Go69KXz-7fyAvuRBWBTE8pxgAnnvjrwapUeQ0PAWTrDO3uu_3ENa09pMHs_UoDuPzGT861yPniIC8Ggx5hWiswl_dCc4lXP5409FAwD27L3XYkHuHfjAg"/>
+	    </form>
    </body>
-  </html>`;
+</html>`;
 
 describe("getJwtFromFormPost", () => {
   it("should return the correct JWT", async () => {
     const { jwt } = await getJwtFromFormPost(fakeFormPost);
 
     expect(jwt).toEqual(
-      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmV4YW1wbGUuY29tIiwiYXVkIjoiczZCaGRSa3F0MyIsImV4cCI6MTMxMTI4MTk3MCwiYWNjZXNzX3Rva2VuIjoiMllvdG5GWkZFanIxekNzaWNNV3BBQSIsInN0YXRlIjoiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2SDlqc1luaTlkTUFKdyIsInRva2VuX3R5cGUiOiJiZWFyZXIiLCJleHBpcmVzX2luIjoiMzYwMCIsInNjb3BlIjoiZXhhbXBsZSJ9.bgHLOu2dlDjtCnvTLK7hTN_JNwoZXEBnbXQx5vd9z17v1HyzfMqz00Vi002T-SWf2JEs3IVSvAe1xWLIY0TeuaiegklJx_gvB59SQIhXX2ifzRmqPoDdmJGaWZ3tnRyFWNnEogJDqGFCo2RHtk8fXkE5IEiBD0g-tN0GS_XnxlE"
+      "eyJraWQiOiJlTk4tZzVpNkNuTEtjbHRRQnA2YWJiaW9HTWJ6TTZtdVczdnV4dzZ1aDg4IiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwaS5ldWRpLXdhbGxldC1pdC1waWQtcHJvdmlkZXIuaXQiLCJjb2RlIjoic1d6YlNWbC0wUlZ1WGkzclNSeUVQT3ZZM2k0cUZYTXkteV9HbFhyRVdZSSIsInN0YXRlIjoiYzQwZmRiMzctMmJmOC00ZjUzLTg4ZTUtNTY2ZjA5MGQxMjgzIn0.uZtN5FXNFgL-7D0U1ELLOLq_0a6MIg6BFHSVutolqnmJLYnbvlmONvNCTJ3kaWjy7mnNU41MbU4n0VH82-7rJ9ZBYA2Hr1nbgiHJTh38tXRnxjnyE7G1XYxxYEMSRV2Avm4ahSXUlo-tQnzbzFEm9_-2iFxoaVpUjU9crXxfGwRkvX_TAwS7zPeLBIEolLfgDc6ZRvNpmulbVVY_z4vVRlwIQg7N-cLN_Go69KXz-7fyAvuRBWBTE8pxgAnnvjrwapUeQ0PAWTrDO3uu_3ENa09pMHs_UoDuPzGT861yPniIC8Ggx5hWiswl_dCc4lXP5409FAwD27L3XYkHuHfjAg"
     );
   });
 

--- a/src/utils/__tests__/decoder.test.ts
+++ b/src/utils/__tests__/decoder.test.ts
@@ -1,0 +1,35 @@
+import { getJwtFromFormPost } from "../decoder";
+import { ValidationFailed } from "../errors";
+
+const fakeFormPost = `<html>
+ <head><title>Submit This Form</title></head>
+ <body onload="javascript:document.forms[0].submit()">
+  <form method="post" action="https://client.example.com/cb">
+    <input type="hidden" name="response"
+     value="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2
+      FjY291bnRzLmV4YW1wbGUuY29tIiwiYXVkIjoiczZCaGRSa3F0MyIsImV4cCI6MTM
+      xMTI4MTk3MCwiYWNjZXNzX3Rva2VuIjoiMllvdG5GWkZFanIxekNzaWNNV3BBQSIs
+      InN0YXRlIjoiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2SDlqc1luaTlkT
+      UFKdyIsInRva2VuX3R5cGUiOiJiZWFyZXIiLCJleHBpcmVzX2luIjoiMzYwMCIsIn
+      Njb3BlIjoiZXhhbXBsZSJ9.bgHLOu2dlDjtCnvTLK7hTN_JNwoZXEBnbXQx5vd9z1
+      7v1HyzfMqz00Vi002T-SWf2JEs3IVSvAe1xWLIY0TeuaiegklJx_gvB59SQIhXX2i
+      fzRmqPoDdmJGaWZ3tnRyFWNnEogJDqGFCo2RHtk8fXkE5IEiBD0g-tN0GS_XnxlE"/>
+    </form>
+   </body>
+  </html>`;
+
+describe("getJwtFromFormPost", () => {
+  it("should return the correct JWT", async () => {
+    const { jwt } = await getJwtFromFormPost(fakeFormPost);
+
+    expect(jwt).toEqual(
+      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmV4YW1wbGUuY29tIiwiYXVkIjoiczZCaGRSa3F0MyIsImV4cCI6MTMxMTI4MTk3MCwiYWNjZXNzX3Rva2VuIjoiMllvdG5GWkZFanIxekNzaWNNV3BBQSIsInN0YXRlIjoiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2SDlqc1luaTlkTUFKdyIsInRva2VuX3R5cGUiOiJiZWFyZXIiLCJleHBpcmVzX2luIjoiMzYwMCIsInNjb3BlIjoiZXhhbXBsZSJ9.bgHLOu2dlDjtCnvTLK7hTN_JNwoZXEBnbXQx5vd9z17v1HyzfMqz00Vi002T-SWf2JEs3IVSvAe1xWLIY0TeuaiegklJx_gvB59SQIhXX2ifzRmqPoDdmJGaWZ3tnRyFWNnEogJDqGFCo2RHtk8fXkE5IEiBD0g-tN0GS_XnxlE"
+    );
+  });
+
+  it("should fail the decode", async () => {
+    await expect(getJwtFromFormPost("<html></html>")).rejects.toThrowError(
+      ValidationFailed
+    );
+  });
+});

--- a/src/utils/decoder.ts
+++ b/src/utils/decoder.ts
@@ -1,0 +1,43 @@
+import { decode as decodeJwt } from "@pagopa/io-react-native-jwt";
+import type { JWTDecodeResult } from "@pagopa/io-react-native-jwt/lib/typescript/types";
+import { ValidationFailed } from "./errors";
+
+/*
+ * Decode a form_post.jwt and return the final JWT.
+ * The formData here is in form_post.jwt format as defined in
+ * JWT Secured Authorization Response Mode for OAuth 2.0 (JARM)
+ * HTTP/1.1 200 OK
+ *   Content-Type: text/html;charset=UTF-8
+ *   Cache-Control: no-cache, no-store
+ *   Pragma: no-cache
+ *
+ *   <html>
+ *   <head><title>Submit This Form</title></head>
+ *   <body onload="javascript:document.forms[0].submit()">
+ *     <form method="post" action="https://client.example.com/cb">
+ *       <input type="hidden" name="response"
+ *       value="eyJhbGciOiJSUz....."/>
+ *       </form>
+ *    </body>
+ *   </html>
+ */
+export const getJwtFromFormPost = async (
+  formData: string
+): Promise<{ jwt: string; decodedJwt: JWTDecodeResult }> => {
+  const formPostRegex = /value\s*=\s*"((.|\n)*)"/gm;
+  const lineExpressionRegex = /\r\n|\n\r|\n|\r|\s+/g;
+
+  const matches = formPostRegex.exec(formData);
+  if (matches && matches.length >= 1) {
+    const responseJwt = matches[1];
+    if (responseJwt) {
+      const jwt = responseJwt.replace(lineExpressionRegex, "");
+      const decodedJwt = await decodeJwt(jwt);
+      return { jwt, decodedJwt };
+    }
+  }
+
+  throw new ValidationFailed(
+    `Unable to obtain JWT from form_post.jwt. Form data: ${formData}`
+  );
+};

--- a/src/utils/decoder.ts
+++ b/src/utils/decoder.ts
@@ -30,7 +30,7 @@ export const getJwtFromFormPost = async (
   const matches = formPostRegex.exec(formData);
   if (matches && matches.length >= 2) {
     const responseJwt = matches[2];
-    console.log(matches);
+
     if (responseJwt) {
       const jwt = responseJwt.replace(lineExpressionRegex, "");
       const decodedJwt = await decodeJwt(jwt);

--- a/src/utils/decoder.ts
+++ b/src/utils/decoder.ts
@@ -24,12 +24,13 @@ import { ValidationFailed } from "./errors";
 export const getJwtFromFormPost = async (
   formData: string
 ): Promise<{ jwt: string; decodedJwt: JWTDecodeResult }> => {
-  const formPostRegex = /value\s*=\s*"((.|\n)*)"/gm;
+  const formPostRegex = /<input(.|\n)*value\s*=\s*"((.|\n)*)"(.|\n)*>/gm;
   const lineExpressionRegex = /\r\n|\n\r|\n|\r|\s+/g;
 
   const matches = formPostRegex.exec(formData);
-  if (matches && matches.length >= 1) {
-    const responseJwt = matches[1];
+  if (matches && matches.length >= 2) {
+    const responseJwt = matches[2];
+    console.log(matches);
     if (responseJwt) {
       const jwt = responseJwt.replace(lineExpressionRegex, "");
       const decodedJwt = await decodeJwt(jwt);


### PR DESCRIPTION
Adds the call to the authorization endpoint to obtain the PID.

#### List of Changes
- Introduces a breaking change to `PID.Issuing.getCredential` and `PID.Issuing.authorizeIssuing`. In particular, the user data must be passed to `authorizeIssuing` and no longer to `getCredential`.
- Adds support for form_post as defined in https://github.com/italia/eudi-wallet-it-docs/issues/132

#### Motivation and Context
See https://github.com/italia/eudi-wallet-it-docs/issues/132

#### How Has This Been Tested?
Unit tested and with simulator


#### Checklist:
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
