### PR TITLE
fix!: [SIW-631] `StartFlow` to be syncronous

### DIFF
--- a/example/src/scenarios/cross-device-flow-with-rp.tsx
+++ b/example/src/scenarios/cross-device-flow-with-rp.tsx
@@ -24,7 +24,7 @@ export default async (
 
     // Scan/Decode QR
     const { requestURI: authRequestUrl, clientId } =
-      await Credential.Presentation.startFlowFromQR(qr);
+      Credential.Presentation.startFlowFromQR(qr);
 
     // resolve RP's entity configuration
     const { rpConf } = await Credential.Presentation.evaluateRelyingPartyTrust(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-wallet",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Provide data structures, helpers and API for IO Wallet",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/credential/issuance/01-start-flow.ts
+++ b/src/credential/issuance/01-start-flow.ts
@@ -4,7 +4,7 @@
  *
  * @returns The type of the Credential to be issued and the url of the Issuer
  */
-export type StartFlow = () => Promise<{
+export type StartFlow = () => {
   issuerUrl: string;
   credentialType: string;
-}>;
+};

--- a/src/credential/presentation/01-start-flow.ts
+++ b/src/credential/presentation/01-start-flow.ts
@@ -16,10 +16,10 @@ const QRCodePayload = z.object({
  * @param Optional parameters, depending on the starting touchoint
  * @returns The url for the Relying Party to connect with
  */
-export type StartFlow<T extends Array<unknown> = []> = (...args: T) => Promise<{
+export type StartFlow<T extends Array<unknown> = []> = (...args: T) => {
   requestURI: string;
   clientId: string;
-}>;
+};
 
 /**
  * Start a presentation flow by decoding an incoming QR-code
@@ -28,7 +28,7 @@ export type StartFlow<T extends Array<unknown> = []> = (...args: T) => Promise<{
  * @returns The url for the Relying Party to connect with
  * @throws If the provided qr code fails to be decoded
  */
-export const startFlowFromQR: StartFlow<[string]> = async (qrcode) => {
+export const startFlowFromQR: StartFlow<[string]> = (qrcode) => {
   const decoded = decodeBase64(qrcode);
   const decodedUrl = new URL(decoded);
   const protocol = decodedUrl.protocol;

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -20,4 +20,6 @@ export const hasStatus =
 // helpful to bind the input of a function to the output of another
 export type Out<FN> = FN extends (...args: any[]) => Promise<any>
   ? Awaited<ReturnType<FN>>
+  : FN extends (...args: any[]) => any
+  ? ReturnType<FN>
   : never;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* `StartFlow` as sync function
* `Out` to handle both sync and async functions

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
`StartFlow` is a generic function signature that maps any touchpoint the User can use to start the Issuance and Presentation processes. It was introduced in #62.
Touchpoint may be:
* QR code scanning (cross-device)
* Select an element from a list (same device)
* URL decode (same device)

We found out it's better to keep it synchronous

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Type system check

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
