### PR TITLE
feat: [SIW-678] Support issuing credential in `mdoc-cbor` format

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -55,6 +55,10 @@ export default function App() {
           title="Get Credential"
           scenario={scenarios.getCredential}
         />
+        <TestScenario
+          title="Get Multiple Credential"
+          scenario={scenarios.getMultipleCredential}
+        />
         <TestScenario title="Decode QR from RP" scenario={scenarios.decodeQR} />
         <TestScenario
           title="Fetch Entity Statement"

--- a/example/src/scenarios/get-credential-multiple.tsx
+++ b/example/src/scenarios/get-credential-multiple.tsx
@@ -1,0 +1,192 @@
+import {
+  Credential,
+  Trust,
+  createCryptoContextFor,
+} from "@pagopa/io-react-native-wallet";
+import { error, result, toResultOrReject } from "./types";
+import getWalletInstanceAttestation from "./get-attestation";
+import { generate } from "@pagopa/io-react-native-crypto";
+import getPid from "./get-pid";
+import type { CryptoContext } from "@pagopa/io-react-native-jwt";
+
+const walletProviderBaseUrl = "https://io-d-wallet-it.azurewebsites.net";
+
+const rnd = () => Math.random().toString(36).substr(2, 5);
+
+// Workaround for Typescript parent narrowing
+// credit: https://github.com/microsoft/TypeScript/issues/42384#issuecomment-1083119502
+function assertField<
+  T extends { [field in Field]?: T[field] },
+  Field extends keyof T & string
+>(
+  obj: T,
+  field: Field
+): obj is T & { [field in Field]: NonNullable<T[field]> } {
+  if (!obj[field]) false;
+  return true;
+}
+
+// PID presentation flow as a User Authorization method
+const completeUserAuthorizationWithPID =
+  ({
+    rpConf,
+    walletInstanceAttestation,
+    wiaCryptoContext,
+  }: {
+    rpConf: Trust.RelyingPartyEntityConfiguration["payload"]["metadata"];
+    wiaCryptoContext: CryptoContext;
+    walletInstanceAttestation: string;
+  }): Credential.Issuance.CompleteUserAuthorization =>
+  async (requestUri, _clientId) => {
+    // assume PID is already obtained by the wallet
+    const pidKeyTag = rnd();
+    const pidToken = await getPid(pidKeyTag).then(toResultOrReject);
+    const pidCryptoContext = createCryptoContextFor(pidKeyTag);
+
+    // select claims to be disclose from pid
+    // these would be selected by users in the UI
+    const claims = [
+      "unique_id",
+      "given_name",
+      "family_name",
+      "birthdate",
+      "place_of_birth",
+      "tax_id_number",
+      "evidence",
+    ];
+
+    // get request object
+    const { requestObject } = await Credential.Presentation.getRequestObject(
+      requestUri,
+      rpConf,
+      {
+        wiaCryptoContext,
+        walletInstanceAttestation,
+      }
+    );
+
+    // Submit authorization response
+    const { response_code } =
+      await Credential.Presentation.sendAuthorizationResponse(
+        requestObject,
+        rpConf,
+        [pidToken, claims, pidCryptoContext],
+        {
+          walletInstanceAttestation,
+        }
+      );
+
+    return { code: response_code || "code" };
+  };
+
+export default async () => {
+  try {
+    // obtain wallet instance attestation
+    const walletInstanceKeyTag = rnd();
+    const wiaCryptoContext = createCryptoContextFor(walletInstanceKeyTag);
+    const walletInstanceAttestation = await getWalletInstanceAttestation(
+      walletInstanceKeyTag
+    ).then(toResultOrReject);
+
+    const { type: credentialType, url: credentialProviderBaseUrl } =
+      /* startFLow()*/ {
+        type: "mDL",
+        url: "https://api.eudi-wallet-it-issuer.it/rp",
+      };
+
+    const { issuerConf } = await Credential.Issuance.evaluateIssuerTrust(
+      credentialProviderBaseUrl
+    );
+
+    const { clientId, requestUri } =
+      await Credential.Issuance.startUserAuthorization(
+        issuerConf,
+        credentialType,
+        {
+          walletInstanceAttestation,
+          walletProviderBaseUrl,
+          wiaCryptoContext,
+        }
+      );
+
+    // Enforcing Issuer to have relying party configuration
+    if (!assertField(issuerConf, "wallet_relying_party")) {
+      throw new Error(
+        "Expecting the Credential Issuer to act as a Relying Party in order to accept PID presentation"
+      );
+    }
+
+    // PID presentation sub-flow
+    const { code } = await completeUserAuthorizationWithPID({
+      rpConf: issuerConf,
+      walletInstanceAttestation,
+      wiaCryptoContext,
+    })(requestUri, clientId);
+
+    const { accessToken, nonce } = await Credential.Issuance.authorizeAccess(
+      issuerConf,
+      code,
+      clientId,
+      {
+        walletInstanceAttestation,
+        walletProviderBaseUrl,
+      }
+    );
+
+    const credentialKeyTag = rnd();
+    await generate(credentialKeyTag);
+    const credentialCryptoContext = createCryptoContextFor(credentialKeyTag);
+
+    const sdjwtCredential = await Credential.Issuance.obtainCredential(
+      issuerConf,
+      accessToken,
+      "nonce",
+      clientId,
+      credentialType,
+      "vc+sd-jwt",
+      {
+        walletProviderBaseUrl,
+        credentialCryptoContext,
+      }
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _mdocCredential = await Credential.Issuance.obtainCredential(
+      issuerConf,
+      accessToken,
+      // use nonce from previous credential otherwise
+      // the issuer will reject the request to prevent replay attacks
+      sdjwtCredential.nonce,
+      clientId,
+      credentialType,
+      "vc+mdoc-cbor",
+      {
+        walletProviderBaseUrl,
+        credentialCryptoContext,
+      }
+    );
+
+    const parsedCredentials = await Promise.all(
+      [
+        sdjwtCredential,
+        // TODO: [SIW-686] decode MDOC credentials
+        /*  _mdocCredential */
+      ].map((c) =>
+        Credential.Issuance.verifyAndParseCredential(
+          issuerConf,
+          c.credential,
+          c.format,
+          { credentialCryptoContext, ignoreMissingAttributes: true }
+        )
+      )
+    );
+
+    const parsedCredential = parsedCredentials[0]?.parsedCredential || {};
+    console.log(parsedCredential);
+
+    return result(parsedCredential);
+  } catch (e) {
+    console.error(e);
+    return error(e);
+  }
+};

--- a/example/src/scenarios/get-credential.tsx
+++ b/example/src/scenarios/get-credential.tsx
@@ -143,6 +143,7 @@ export default async () => {
       nonce,
       clientId,
       credentialType,
+      "vc+sd-jwt",
       {
         walletProviderBaseUrl,
         credentialCryptoContext,

--- a/example/src/scenarios/get-pid.tsx
+++ b/example/src/scenarios/get-pid.tsx
@@ -85,6 +85,7 @@ export default async (credentialKeyTag = rnd()) => {
       nonce,
       clientId,
       credentialType,
+      "vc+sd-jwt",
       {
         walletProviderBaseUrl,
         credentialCryptoContext,

--- a/example/src/scenarios/index.tsx
+++ b/example/src/scenarios/index.tsx
@@ -8,11 +8,13 @@ import verifyCredentialSdJwt from "./verify-credential-sdjwt";
 import decodeQR from "./decode-qr-from-rp";
 import authenticationToRP from "./cross-device-flow-with-rp";
 import getCredential from "./get-credential";
+import getMultipleCredential from "./get-credential-multiple";
 
 const scenarios = {
   getPid,
   getAttestation,
   getCredential,
+  getMultipleCredential,
   verifyPid,
   decodePid,
   decodeQR,

--- a/src/credential/issuance/06-obtain-credential.ts
+++ b/src/credential/issuance/06-obtain-credential.ts
@@ -36,6 +36,10 @@ export const createNonceProof = async (
 const CredentialEndpointResponse = z.object({
   credential: z.string(),
   format: SupportedCredentialFormat,
+  // nonce used to perform multiple credential requests
+  // re-using the same authorization profile
+  c_nonce: z.string(),
+  c_nonce_expires_in: z.number(),
 });
 
 export type ObtainCredential = (
@@ -50,7 +54,11 @@ export type ObtainCredential = (
     walletProviderBaseUrl: string;
     appFetch?: GlobalFetch["fetch"];
   }
-) => Promise<{ credential: string; format: SupportedCredentialFormat }>;
+) => Promise<{
+  credential: string;
+  format: SupportedCredentialFormat;
+  nonce: string;
+}>;
 
 // Checks whether in the Entity confoguration at least one credential
 // is defined for the given type and format
@@ -142,7 +150,7 @@ export const obtainCredential: ObtainCredential = async (
     }),
   });
 
-  const { credential, format } = await appFetch(credentialUrl, {
+  const { credential, format, c_nonce } = await appFetch(credentialUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -155,5 +163,5 @@ export const obtainCredential: ObtainCredential = async (
     .then((res) => res.json())
     .then(CredentialEndpointResponse.parse);
 
-  return { credential, format };
+  return { credential, format, nonce: c_nonce };
 };

--- a/src/credential/issuance/07-verify-and-parse-credential.ts
+++ b/src/credential/issuance/07-verify-and-parse-credential.ts
@@ -196,6 +196,15 @@ const verifyAndParseCredentialSdJwt: WithFormat<"vc+sd-jwt"> = async (
   return { parsedCredential };
 };
 
+const verifyAndParseCredentialMdoc: WithFormat<"vc+mdoc-cbor"> = async (
+  _issuerConf,
+  _credential,
+  _,
+  _ctx
+) => {
+  throw new Error("verifyAndParseCredentialMdoc not implemented yet");
+};
+
 /**
  * Verify and parse an encoded credential
  *
@@ -217,6 +226,13 @@ export const verifyAndParseCredential: VerifyAndParseCredential = async (
 ) => {
   if (format === "vc+sd-jwt") {
     return verifyAndParseCredentialSdJwt(
+      issuerConf,
+      credential,
+      format,
+      context
+    );
+  } else if (format === "vc+mdoc-cbor") {
+    return verifyAndParseCredentialMdoc(
       issuerConf,
       credential,
       format,

--- a/src/credential/issuance/07-verify-and-parse-credential.ts
+++ b/src/credential/issuance/07-verify-and-parse-credential.ts
@@ -202,6 +202,7 @@ const verifyAndParseCredentialMdoc: WithFormat<"vc+mdoc-cbor"> = async (
   _,
   _ctx
 ) => {
+  // TODO: [SIW-686] decode MDOC credentials
   throw new Error("verifyAndParseCredentialMdoc not implemented yet");
 };
 

--- a/src/credential/issuance/const.ts
+++ b/src/credential/issuance/const.ts
@@ -5,4 +5,7 @@ export const ASSERTION_TYPE =
 export type SupportedCredentialFormat = z.infer<
   typeof SupportedCredentialFormat
 >;
-export const SupportedCredentialFormat = z.literal("vc+sd-jwt");
+export const SupportedCredentialFormat = z.union([
+  z.literal("vc+sd-jwt"),
+  z.literal("vc+mdoc-cbor"),
+]);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Allow mdoc-cbor format
* Allow multiple credential requests with a single authorization profile

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
As per ARF, credentials are served in SD-JWT or mDoc-CBOR format. 
Moreover, for many credentials both formats are provided thus we enable the user to obtain both at once.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
example app


#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
