### PR TITLE
chore: Pin `yarn` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "engines": {
     "node": ">= 16.0.0"
   },
-  "packageManager": "^yarn@1.22.21",
+  "packageManager": "yarn@1.22.19",
   "jest": {
     "preset": "react-native",
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
For some reasons GitHub actions started to fail. It seems to be linked to https://github.com/yarnpkg/yarn/issues/9015, but I couldn't prove it.

kudos to @sebbalex for the hint!