### PR TITLE
fix: [SIW-762] Credential parsing with undefined attributes

### DIFF
--- a/src/credential/issuance/07-verify-and-parse-credential.ts
+++ b/src/credential/issuance/07-verify-and-parse-credential.ts
@@ -89,45 +89,49 @@ const parseCredentialSdJwt = (
 
   // attributes that are defined in the issuer configuration
   // and are present in the disclosure set
-  const definedValues = attrDefinitions
-    // retrieve the value from the disclosure set
-    .map(
-      ([attrKey, definition]) =>
-        [
-          attrKey,
-          {
-            ...definition,
-            value: disclosures.find(
-              (_) => _[1 /* name */] === attrKey
-            )?.[2 /* value */],
-          },
-        ] as const
-    )
-    // add a human readable attribute name, with i18n, in the form { locale: name }
-    // example: { "it-IT": "Nome", "en-EN": "Name", "es-ES": "Nombre" }
-    .map(
-      ([attrKey, { display, ...definition }]) =>
-        [
-          attrKey,
-          {
-            ...definition,
-            name: display.reduce(
-              (names, { locale, name }) => ({ ...names, [locale]: name }),
-              {} as Record<string, string>
-            ),
-          },
-        ] as const
-    );
+  const definedValues = Object.fromEntries(
+    attrDefinitions
+      // retrieve the value from the disclosure set
+      .map(
+        ([attrKey, definition]) =>
+          [
+            attrKey,
+            {
+              ...definition,
+              value: disclosures.find(
+                (_) => _[1 /* name */] === attrKey
+              )?.[2 /* value */],
+            },
+          ] as const
+      )
+      // add a human readable attribute name, with i18n, in the form { locale: name }
+      // example: { "it-IT": "Nome", "en-EN": "Name", "es-ES": "Nombre" }
+      .map(
+        ([attrKey, { display, ...definition }]) =>
+          [
+            attrKey,
+            {
+              ...definition,
+              name: display.reduce(
+                (names, { locale, name }) => ({ ...names, [locale]: name }),
+                {} as Record<string, string>
+              ),
+            },
+          ] as const
+      )
+  );
 
   // attributes that are in the disclosure set
   // but are not defined in the issuer configuration
-  const undefinedValues = disclosures
-    .filter((_) => !Object.keys(definedValues).includes(_[1]))
-    .map(([, key, value]) => [key, { value, mandatory: false, name: key }]);
+  const undefinedValues = Object.fromEntries(
+    disclosures
+      .filter((_) => !Object.keys(definedValues).includes(_[1]))
+      .map(([, key, value]) => [key, { value, mandatory: false, name: key }])
+  );
 
   return {
-    ...Object.fromEntries(definedValues),
-    ...Object.fromEntries(undefinedValues),
+    ...definedValues,
+    ...undefinedValues,
   };
 };
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Co-authored by @balanza 

#### List of Changes
Converts the list of disclosures key-value pairs into an object before constructing the list of attributes that are not defined in the issuer configuration.

<!--- Describe your changes in detail -->

#### Motivation and Context
This change fixes an issue which occurs when the credential has disclosures not defined in the issuer configuration and the `ignoreMissingAttributes` is set to `true`. 
The issue is caused by a missing conversion of the disclosures key-value pairs into an object which causes a duplication of defined disclosures in the undefined list. 
This leads to an overwrite of the defined disclosure when the two lists are merged in the function return.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
By testing the `mDL` issuance (SD-JTW). The verified and parsed credential should have each disclosures with a locale.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
