### PR TITLE
chore: Add `react-native-dotenv` for example app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ lib/
 
 # testing
 /coverage
+
+#Example env
+example/.env

--- a/example/.env.example
+++ b/example/.env.example
@@ -1,0 +1,1 @@
+WALLET_PROVIDER_BASE_URL=https://walletprovider.example.org

--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -13,5 +13,6 @@ module.exports = {
         },
       },
     ],
+    ["module:react-native-dotenv"],
   ],
 };

--- a/example/ios/IoReactNativeWalletExample.xcodeproj/project.pbxproj
+++ b/example/ios/IoReactNativeWalletExample.xcodeproj/project.pbxproj
@@ -606,7 +606,10 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 			};
@@ -676,7 +679,10 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/example/package.json
+++ b/example/package.json
@@ -29,6 +29,7 @@
     "@react-native/metro-config": "^0.72.12",
     "babel-plugin-module-resolver": "^5.0.0",
     "metro-react-native-babel-preset": "^0.76.9",
+    "react-native-dotenv": "^3.4.11",
     "react-native-url-polyfill": "^2.0.0"
   },
   "engines": {

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -1,0 +1,3 @@
+declare module "@env" {
+  export const WALLET_PROVIDER_BASE_URL: string;
+}

--- a/example/src/scenarios/create-wallet-instance.tsx
+++ b/example/src/scenarios/create-wallet-instance.tsx
@@ -9,7 +9,9 @@ import {
   isAttestationServiceAvailable,
 } from "@pagopa/io-react-native-integrity";
 
-const walletProviderBaseUrl = "http://127.0.0.1:8000";
+import { WALLET_PROVIDER_BASE_URL } from "@env";
+
+const walletProviderBaseUrl = WALLET_PROVIDER_BASE_URL;
 
 export default async () => {
   try {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2489,6 +2489,11 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
+dotenv@^16.4.5:
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -4529,6 +4534,13 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-native-dotenv@^3.4.11:
+  version "3.4.11"
+  resolved "https://registry.yarnpkg.com/react-native-dotenv/-/react-native-dotenv-3.4.11.tgz#2e6c4eabd55d5f1bf109b3dd9141dadf9c55cdd4"
+  integrity sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg==
+  dependencies:
+    dotenv "^16.4.5"
 
 react-native-safe-area-context@^4.9.0:
   version "4.9.0"


### PR DESCRIPTION
Adds reading the configuration file directly from the `.env` file for the **example app.** 
Avoiding hard-coded URLs.