### PR TITLE
chore: [SIW-1160] Add Android example app

### DIFF
--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -1,3 +1,4 @@
 declare module "@env" {
   export const WALLET_PROVIDER_BASE_URL: string;
+  export const GOOGLE_CLOUD_PROJECT_NUMBER: string;
 }

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -1,4 +1,3 @@
 declare module "@env" {
   export const WALLET_PROVIDER_BASE_URL: string;
-  export const GOOGLE_CLOUD_PROJECT_NUMBER: string;
 }

--- a/example/src/scenarios/create-wallet-instance.tsx
+++ b/example/src/scenarios/create-wallet-instance.tsx
@@ -7,62 +7,21 @@ import {
   generateHardwareKey,
   getAttestation,
   isAttestationServiceAvailable,
-  isPlayServicesAvailable,
 } from "@pagopa/io-react-native-integrity";
 
 import { WALLET_PROVIDER_BASE_URL } from "@env";
-import { generate, type CryptoError } from "@pagopa/io-react-native-crypto";
+import { generate } from "@pagopa/io-react-native-crypto";
 import { Platform } from "react-native";
 
 const walletProviderBaseUrl = WALLET_PROVIDER_BASE_URL;
 
-export default async () =>
-  Platform.select({
-    ios: () => createIos(),
-    android: () => createAndroid(),
-    default: () => Promise.reject(new Error("Unsupported platform")),
-  })();
-
-const createAndroid = async () => {
+export default async () => {
   try {
-    const isPlayServiceAvailable = await isPlayServicesAvailable();
-    if (!isPlayServiceAvailable) {
-      throw new Error("Play services unavailable");
-    }
-
-    const keyTag = `${Math.random()}`;
-
-    await generate(keyTag).catch((e) => {
-      if ((e as CryptoError).message !== "KEY_ALREADY_EXISTS") {
-        throw e;
-      }
-    });
-
-    const integrityContext: IntegrityContext = {
-      getHardwareKeyTag: () => keyTag,
-      getAttestation: (nonce) => getAttestation(nonce, keyTag),
-    };
-
-    const createdWalletInstance = await WalletInstance.createWalletInstance({
-      integrityContext,
-      walletProviderBaseUrl,
-    });
-    console.log(createdWalletInstance);
-    return result(createdWalletInstance);
-  } catch (e) {
-    console.error(e);
-    return error(e);
-  }
-};
-
-const createIos = async () => {
-  try {
-    const isIntegrityAvailable = await isAttestationServiceAvailable();
-    if (!isIntegrityAvailable) {
-      throw new Error("Attestation service unavailable");
-    }
-
-    const hardwareKeyTag = await generateHardwareKey();
+    const hardwareKeyTag = await Platform.select({
+      ios: () => generateKeyIos(),
+      android: () => generateKeyAndroid(),
+      default: () => Promise.reject(new Error("Unsupported platform")),
+    })();
 
     const integrityContext: IntegrityContext = {
       getHardwareKeyTag: () => hardwareKeyTag,
@@ -80,4 +39,30 @@ const createIos = async () => {
     console.error(e);
     return error(e);
   }
+};
+
+/**
+ * Generates the hardware backed key for iOS.
+ * It differents from Android because the key is generated via `io-react-native-integrity` instead of `io-react-native-crypto`.
+ * There's also a check for the availability of the attestation service.
+ * @returns a promise that resolves with the key tag as string.
+ */
+const generateKeyIos = async () => {
+  const isIntegrityAvailable = await isAttestationServiceAvailable();
+  if (!isIntegrityAvailable) {
+    throw new Error("Attestation service unavailable");
+  }
+
+  return await generateHardwareKey();
+};
+
+/**
+ * Generates the hardware backed key for Android.
+ * It differents from iOS because the key is generated via `io-react-native-crypto` instead of `io-react-native-integrity`.
+ * @returns a promise that resolves with the key tag as string.
+ */
+const generateKeyAndroid = async () => {
+  const keyTag = `${Math.random()}`;
+  await generate(keyTag);
+  return keyTag;
 };

--- a/example/src/scenarios/create-wallet-instance.tsx
+++ b/example/src/scenarios/create-wallet-instance.tsx
@@ -8,10 +8,9 @@ import {
   getAttestation,
   isAttestationServiceAvailable,
   isPlayServicesAvailable,
-  prepareIntegrityToken,
 } from "@pagopa/io-react-native-integrity";
 
-import { WALLET_PROVIDER_BASE_URL, GOOGLE_CLOUD_PROJECT_NUMBER } from "@env";
+import { WALLET_PROVIDER_BASE_URL } from "@env";
 import { generate, type CryptoError } from "@pagopa/io-react-native-crypto";
 import { Platform } from "react-native";
 

--- a/example/src/scenarios/create-wallet-instance.tsx
+++ b/example/src/scenarios/create-wallet-instance.tsx
@@ -7,13 +7,56 @@ import {
   generateHardwareKey,
   getAttestation,
   isAttestationServiceAvailable,
+  isPlayServicesAvailable,
+  prepareIntegrityToken,
 } from "@pagopa/io-react-native-integrity";
 
-import { WALLET_PROVIDER_BASE_URL } from "@env";
+import { WALLET_PROVIDER_BASE_URL, GOOGLE_CLOUD_PROJECT_NUMBER } from "@env";
+import { generate, type CryptoError } from "@pagopa/io-react-native-crypto";
+import { Platform } from "react-native";
 
 const walletProviderBaseUrl = WALLET_PROVIDER_BASE_URL;
 
-export default async () => {
+export default async () =>
+  Platform.select({
+    ios: () => createIos(),
+    android: () => createAndroid(),
+    default: () => Promise.reject(new Error("Unsupported platform")),
+  })();
+
+const createAndroid = async () => {
+  try {
+    const isPlayServiceAvailable = await isPlayServicesAvailable();
+    if (!isPlayServiceAvailable) {
+      throw new Error("Play services unavailable");
+    }
+
+    const keyTag = `${Math.random()}`;
+
+    await generate(keyTag).catch((e) => {
+      if ((e as CryptoError).message !== "KEY_ALREADY_EXISTS") {
+        throw e;
+      }
+    });
+
+    const integrityContext: IntegrityContext = {
+      getHardwareKeyTag: () => keyTag,
+      getAttestation: (nonce) => getAttestation(nonce, keyTag),
+    };
+
+    const createdWalletInstance = await WalletInstance.createWalletInstance({
+      integrityContext,
+      walletProviderBaseUrl,
+    });
+    console.log(createdWalletInstance);
+    return result(createdWalletInstance);
+  } catch (e) {
+    console.error(e);
+    return error(e);
+  }
+};
+
+const createIos = async () => {
   try {
     const isIntegrityAvailable = await isAttestationServiceAvailable();
     if (!isIntegrityAvailable) {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds the android example app for the `createWalletInstance` scenario.

#### List of Changes

<!--- Describe your changes in detail -->
- Use `Platform.select` to differentiate between the iOS and Android flow when generating the hardware key. The main difference is that on Android we generate the hardware-backed key via `io-react-native-crypto`.

#### How Has This Been Tested?
Follow these steps to test the flow: 
- Run [io-func-wallet-solution-backend](https://github.com/pagopa/io-wallet/tree/master/apps/io-func-wallet-solution-backend). I can provide the required `local.settings.json` in private if necessary;
- Run the proxy server under `example/dev-proxy`. I can provide the required `.env` in private if necessary. Make sure that `API_HOST` corresponds to the address:port combination of the function started in the previous step (defaults to `http://localhost:7071`);
- Run the example app. I can provide the required `.env` in private if necessary. Make sure that `WALLET_PROVIDER_BASE_URL` corresponds to the address:port combinato of the dev-proxy started in the previous step (defaults to your localhost address).

It has been tested on different Android devices (9,13,14).

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
