### PR TITLE
chore: [SIW-1208] Use base64url for iOS integrity keys

### DIFF
--- a/example/src/scenarios/prepare-integrity-context.ts
+++ b/example/src/scenarios/prepare-integrity-context.ts
@@ -1,11 +1,11 @@
 import { type IntegrityContext } from "@pagopa/io-react-native-wallet";
 
 import { error, result } from "./types";
-import { getAttestation } from "@pagopa/io-react-native-integrity";
 import {
   ensureIntegrityServiceIsReady,
   generateIntegrityHarwareKeyTag,
   getHardwareSignatureWithAuthData,
+  getAttestation,
 } from "../utils/integrity/integrity";
 
 type IntegrityContextSetter = React.Dispatch<
@@ -43,7 +43,7 @@ const getIntegrityContext = async (
   return {
     getHardwareKeyTag: () => hardwareKeyTag,
     getAttestation: (nonce: string) => getAttestation(nonce, hardwareKeyTag),
-    getHardwareSignatureWithAuthData: (clientData) =>
+    getHardwareSignatureWithAuthData: (clientData: string) =>
       getHardwareSignatureWithAuthData(hardwareKeyTag, clientData),
   };
 };

--- a/example/src/utils/integrity/integrity.android.ts
+++ b/example/src/utils/integrity/integrity.android.ts
@@ -4,6 +4,7 @@ import {
   isPlayServicesAvailable,
   prepareIntegrityToken,
   requestIntegrityToken,
+  getAttestation as getAttestationIntegrity,
 } from "@pagopa/io-react-native-integrity";
 import { sha256 } from "js-sha256";
 import uuid from "react-native-uuid";
@@ -50,8 +51,17 @@ const ensureIntegrityServiceIsReady = async () => {
   return true;
 };
 
+/**
+ * Get an hardware attestation on Android.
+ * @param nonce - the nonce to use for the attestation.
+ * @param hardwareKeyTag - the hardware key tag to use for the attestation.
+ */
+const getAttestation = async (nonce: string, hardwareKeyTag: string) =>
+  await getAttestationIntegrity(nonce, hardwareKeyTag);
+
 export {
   generateIntegrityHarwareKeyTag,
   getHardwareSignatureWithAuthData,
   ensureIntegrityServiceIsReady,
+  getAttestation,
 };

--- a/example/src/utils/integrity/integrity.ios.ts
+++ b/example/src/utils/integrity/integrity.ios.ts
@@ -11,6 +11,7 @@ import { addPadding, removePadding } from "@pagopa/io-react-native-jwt";
 /**
  * Generates the hardware backed key for iOS.
  * On iOS the key is generated via `io-react-native-integrity` and it's then converted from a base64 string to a base64url string.
+ * A base64 string might not be safe to be stored in a database, so it's converted to a base64url string.
  * @returns a promise that resolves with the key tag as string or rejects with an error.
  */
 const generateIntegrityHarwareKeyTag = async () => {
@@ -41,14 +42,14 @@ const getHardwareSignatureWithAuthData = async (
 };
 
 /**
- * Get an hardware attestation on Android.
+ * Get an hardware attestation on iOS.
  * @param nonce - the nonce to use for the attestation.
- * @param hardwareKeyTag - the hardware key tag to use for the attestation.
+ * @param hardwareKeyTag - the hardware key tag to use for the attestation in base64 format.
  */
 const getAttestation = async (nonce: string, hardwareKeyTag: string) => {
   // The generateIntegrityHarwareKeyTag returns a base64url string, so we need to convert it to a base64 string before using it.
   const base64keyTag = addPadding(hardwareKeyTag);
-  await getAttestationIntegrity(nonce, base64keyTag);
+  return await getAttestationIntegrity(nonce, base64keyTag);
 };
 
 export {

--- a/src/utils/integrity.ts
+++ b/src/utils/integrity.ts
@@ -1,7 +1,7 @@
 /**
  * Interface for the integrity context which provides the necessary functions to interact with the integrity service.
  * The functions are platform specific and must be implemented in the platform specific code.
- * getHardwareKeyTag: returns the hardware key tag.
+ * getHardwareKeyTag: returns the hardware key tag in a url safe format (e.g. base64url).
  * getAttestation: requests the attestation from the integrity service.
  * getHardwareSignatureWithAuthData: signs the clientData and returns the signature with the authenticator data.
  */


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Edit `generateIntegrityHarwareKeyTag` to use the function exposed `io-react-native-jwt` to convert the `base64` key returned from the native method to `base64url`;
- Edit `getHardwareSignatureWithAuthData` and `getAttestation` to convert the `base64url` key used in this package to `base64` which is what `io-react-native-integrity` uses;
- Defines `getAttestation` for Android as well due to different implementation which previously converged into the same native method.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Currently, `io-wallet` might return a `500` while creating a wallet instance on iOS due to the hardware key tag being encoded in base64 and thus having characters which can't be stored on the underlying Cosmos DB.
This PR converts the `base64` key tag to `base64url` in the `IntegrityContext`, thus making it safe to be stored on Cosmos DB. 
This doesn't happen on Android as the we can decide the name of the key tag used.

I belive this change belongs to this package rather than `io-react-native-integrity` which should be agnostic.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Run an instance of `apps/io-wallet-user-func` from [io-wallet](https://github.com/pagopa/io-wallet) with an appropriate `local.settings.json` (I can provide it privately) by pointing at the branch used for [this PR](https://github.com/pagopa/io-wallet/pull/120);
- Run an instance of `dev-proxy` in this example folder by providing a `.env` file pointing at the running azure function of the previous point (`http://localhost:7071/api/v1` by default). I can provide the remaining variables privately);
- Run the example app on both Android and iOS by providing a `.env` file. The `WALLET_PROVIDER_BASE_URL` should point to the IP of your local machine URL where the `dev-proxy` is running (again, I can provide the remaining variables privately). Consequentially press every available button in the app and everything should work just fine.

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
