### PR TITLE
feat: [SIW 1190]: handle errors to determine a Wallet Instance status

### DIFF
--- a/example/src/scenarios/get-attestation.ts
+++ b/example/src/scenarios/get-attestation.ts
@@ -2,6 +2,7 @@ import { generate } from "@pagopa/io-react-native-crypto";
 import {
   WalletInstanceAttestation,
   createCryptoContextFor,
+  Errors,
   type IntegrityContext,
 } from "@pagopa/io-react-native-wallet";
 import { error, result } from "./types";
@@ -32,6 +33,12 @@ export default (integrityContext?: IntegrityContext) =>
 
       return result(issuingAttestation);
     } catch (e) {
+      if (e instanceof Errors.WalletInstanceRevokedError) {
+        console.error("Wallet Instance revoked");
+      }
+      if (e instanceof Errors.WalletInstanceNotFoundError) {
+        console.error("Wallet Instance not found");
+      }
       console.error(e);
       return error(e);
     }

--- a/openapi/wallet-provider.yaml
+++ b/openapi/wallet-provider.yaml
@@ -1,23 +1,8 @@
 openapi: 3.0.3
 info:
-  title: IO Wallet
+  title: IO Wallet - User API
   version: 1.0.0
 paths:
-  /.well-known/openid-federation:
-    get:
-      operationId: getEntityConfiguration
-      summary: Returns entity configuration
-      responses:
-        "200":
-          description: Successful operation
-          content:
-            application/entity-statement+jwt:
-              schema:
-                type: string
-                example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
-        "500":
-          $ref: "#/components/responses/Unexpected"
-
   /nonce:
     get:
       operationId: getNonce
@@ -28,12 +13,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  nonce:
-                    type: string
-                required:
-                  - nonce
+                $ref: "#/components/schemas/NonceDetailView"
         "500":
           $ref: "#/components/responses/Unexpected"
 
@@ -46,18 +26,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                challenge:
-                  type: string
-                key_attestation:
-                  type: string
-                hardware_key_tag:
-                  type: string
-              required:
-                - challenge
-                - key_attestation
-                - hardware_key_tag
+              $ref: "#/components/schemas/CreateWalletInstanceBody"
       responses:
         "204":
           description: Wallet instance successfully created
@@ -76,24 +45,20 @@ paths:
         content:
           application/x-www-form-urlencoded:
             schema:
-              type: object
-              properties:
-                grant_type:
-                  type: string
-                  enum: ["urn:ietf:params:oauth:grant-type:jwt-bearer"]
-                assertion:
-                  type: string
-                  example: eyJhbGciOiJFUzI1NiIsImtpZCI6InZiZVhKa3NNNDV4cGh0QU5uQ2lHNm1DeXVVNGpmR056b3BHdUt2b2dnOWMiLCJ0eXAiOiJ3YXIrand0In0.eyJpc3MiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9pbnN0YW5jZS92YmVYSmtzTTQ1eHBodEFObkNpRzZtQ3l1VTRqZkdOem9wR3VLdm9nZzljIiwic3ViIjoiaHR0cHM6Ly93YWxsZXQtcHJvdmlkZXIuZXhhbXBsZS5vcmcvIiwiY2hhbGxlbmdlIjoiNmVjNjkzMjQtNjBhOC00ZTViLWE2OTctYTc2NmQ4NTc5MGVhIiwiaGFyZHdhcmVfc2lnbmF0dXJlIjoiS29aSWh2Y05BUWNDb0lBd2dBSUIuLi5yZWRhY3RlZCIsImludGVncml0eV9hc3NlcnRpb24iOiJvMk5tYlhSdllYQndiR1V0WVhCd1lYLi4ucmVkYWN0ZWQiLCJoYXJkd2FyZV9rZXlfdGFnIjoiV1FoeUR5bUZLc1A5NWlGcXB6ZEVEV1c0bDdhVm5hMkZuNEpDZVdIWXRiVT0iLCJjbmYiOnsiandrIjp7ImNydiI6IlAtMjU2Iiwia3R5IjoiRUMiLCJ4IjoiNEhOcHRJLXhyMnBqeVJKS0dNbno0V21kblFEX3VKU3E0Ujk1Tmo5OGI0NCIsInkiOiJMSVpuU0IzOXZGSmhZZ1MzazdqWEU0cjMtQ29HRlF3WnRQQklScXBObHJnIiwia2lkIjoidmJlWEprc000NXhwaHRBTm5DaUc2bUN5dVU0amZHTnpvcEd1S3ZvZ2c5YyJ9fSwidnBfZm9ybWF0c19zdXBwb3J0ZWQiOnsiand0X3ZjX2pzb24iOnsiYWxnX3ZhbHVlc19zdXBwb3J0ZWQiOlsiRVMyNTZLIiwiRVMzODQiXX0sImp3dF92cF9qc29uIjp7ImFsZ192YWx1ZXNfc3VwcG9ydGVkIjpbIkVTMjU2SyIsIkVkRFNBIl19fSwiaWF0IjoxNjg2NjQ1MTE1LCJleHAiOjE2ODY2NTIzMTV9.F32bisVth4eDdGxDjB9ByENT-oZLtSY_89uwTSePo2GMEKaeEedpXZE_9mrX7t0_Fmc5m6LNVvIIBqotqsYJYQ
-              required:
-                - grant_type
-                - assertion
+              $ref: "#/components/schemas/CreateWalletAttestationBody"
       responses:
         "200":
           description: Wallet Attestation generated
           content:
-            application/entity-statement+jwt:
+            application/jwt:
               schema:
-                type: string
+                $ref: "#/components/schemas/WalletAttestationView"
+        "403":
+          description: The wallet instance was revoked
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The wallet instance was not found
+          $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/UnprocessableContent"
         "500":
@@ -101,6 +66,20 @@ paths:
 
 components:
   responses:
+    Forbidden:
+      description: The server understands the request but refuses to authorize it
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+
+    NotFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+
     UnprocessableContent:
       description: Unprocessable Content
       content:
@@ -116,6 +95,51 @@ components:
             $ref: "#/components/schemas/ProblemDetail"
 
   schemas:
+    NonceDetailView:
+      type: object
+      properties:
+        nonce:
+          type: string
+      required:
+        - nonce
+
+    WalletAttestationView:
+      type: string
+
+    CreateWalletInstanceBody:
+      type: object
+      properties:
+        challenge:
+          type: string
+          minLength: 1
+          format: binary
+        key_attestation:
+          type: string
+          minLength: 1
+          format: binary
+        hardware_key_tag:
+          type: string
+          minLength: 1
+      required:
+        - challenge
+        - key_attestation
+        - hardware_key_tag
+
+    CreateWalletAttestationBody:
+      type: object
+      properties:
+        grant_type:
+          type: string
+          enum: ["urn:ietf:params:oauth:grant-type:jwt-bearer"]
+        assertion:
+          type: string
+          minLength: 1
+          format: binary
+          example: eyJhbGciOiJFUzI1NiIsImtpZCI6InZiZVhKa3NNNDV4cGh0QU5uQ2lHNm1DeXVVNGpmR056b3BHdUt2b2dnOWMiLCJ0eXAiOiJ3YXIrand0In0.eyJpc3MiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9pbnN0YW5jZS92YmVYSmtzTTQ1eHBodEFObkNpRzZtQ3l1VTRqZkdOem9wR3VLdm9nZzljIiwic3ViIjoiaHR0cHM6Ly93YWxsZXQtcHJvdmlkZXIuZXhhbXBsZS5vcmcvIiwiY2hhbGxlbmdlIjoiNmVjNjkzMjQtNjBhOC00ZTViLWE2OTctYTc2NmQ4NTc5MGVhIiwiaGFyZHdhcmVfc2lnbmF0dXJlIjoiS29aSWh2Y05BUWNDb0lBd2dBSUIuLi5yZWRhY3RlZCIsImludGVncml0eV9hc3NlcnRpb24iOiJvMk5tYlhSdllYQndiR1V0WVhCd1lYLi4ucmVkYWN0ZWQiLCJoYXJkd2FyZV9rZXlfdGFnIjoiV1FoeUR5bUZLc1A5NWlGcXB6ZEVEV1c0bDdhVm5hMkZuNEpDZVdIWXRiVT0iLCJjbmYiOnsiandrIjp7ImNydiI6IlAtMjU2Iiwia3R5IjoiRUMiLCJ4IjoiNEhOcHRJLXhyMnBqeVJKS0dNbno0V21kblFEX3VKU3E0Ujk1Tmo5OGI0NCIsInkiOiJMSVpuU0IzOXZGSmhZZ1MzazdqWEU0cjMtQ29HRlF3WnRQQklScXBObHJnIiwia2lkIjoidmJlWEprc000NXhwaHRBTm5DaUc2bUN5dVU0amZHTnpvcEd1S3ZvZ2c5YyJ9fSwidnBfZm9ybWF0c19zdXBwb3J0ZWQiOnsiand0X3ZjX2pzb24iOnsiYWxnX3ZhbHVlc19zdXBwb3J0ZWQiOlsiRVMyNTZLIiwiRVMzODQiXX0sImp3dF92cF9qc29uIjp7ImFsZ192YWx1ZXNfc3VwcG9ydGVkIjpbIkVTMjU2SyIsIkVkRFNBIl19fSwiaWF0IjoxNjg2NjQ1MTE1LCJleHAiOjE2ODY2NTIzMTV9.F32bisVth4eDdGxDjB9ByENT-oZLtSY_89uwTSePo2GMEKaeEedpXZE_9mrX7t0_Fmc5m6LNVvIIBqotqsYJYQ
+      required:
+        - grant_type
+        - assertion
+
     ProblemDetail:
       type: object
       properties:

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -18,16 +18,11 @@ const validateResponse = async (response: Response) => {
       };
     }
 
-    let statusResponse = `Response status code: ${response.status}`;
-
     throw new WalletProviderResponseError(
-      problemDetail.title
-        ? problemDetail.title
-        : "Invalid response from Wallet Provider",
+      problemDetail.title ?? "Invalid response from Wallet Provider",
       problemDetail.type,
-      problemDetail.detail
-        ? statusResponse
-        : `${statusResponse} with detail: ${problemDetail.detail}`
+      problemDetail.detail,
+      response.status
     );
   }
   return response;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -70,46 +70,6 @@ export class ValidationFailed extends IoWalletError {
 }
 
 /**
- * An error subclass thrown when validation fail
- *
- */
-export class WalletInstanceAttestationIssuingError extends IoWalletError {
-  static get code(): "ERR_IO_WALLET_INSTANCE_ATTESTATION_ISSUING_FAILED" {
-    return "ERR_IO_WALLET_INSTANCE_ATTESTATION_ISSUING_FAILED";
-  }
-
-  code = "ERR_IO_WALLET_INSTANCE_ATTESTATION_ISSUING_FAILED";
-
-  /** The Claim for which the validation failed. */
-  claim: string;
-
-  /** Reason code for the validation failure. */
-  reason: string;
-
-  /** HTTP status code */
-  statusCode: number;
-
-  constructor(
-    message: string,
-    claim: string = "unspecified",
-    reason: string = "unspecified",
-    statusCode: number
-  ) {
-    super(
-      serializeAttrs({
-        message,
-        claim,
-        reason,
-        statusCode: statusCode.toString(),
-      })
-    );
-    this.claim = claim;
-    this.reason = reason;
-    this.statusCode = statusCode;
-  }
-}
-
-/**
  * An error subclass thrown when auth request decode fail
  *
  */
@@ -283,5 +243,39 @@ export class WalletProviderResponseError extends IoWalletError {
     this.claim = claim;
     this.reason = reason;
     this.statusCode = statusCode;
+  }
+}
+
+export class WalletInstanceRevokedError extends IoWalletError {
+  static get code(): "ERR_IO_WALLET_INSTANCE_REVOKED" {
+    return "ERR_IO_WALLET_INSTANCE_REVOKED";
+  }
+
+  code = "ERR_IO_WALLET_INSTANCE_REVOKED";
+
+  claim: string;
+  reason: string;
+
+  constructor(message: string, claim: string, reason: string = "unspecified") {
+    super(serializeAttrs({ message, claim, reason }));
+    this.reason = reason;
+    this.claim = claim;
+  }
+}
+
+export class WalletInstanceNotFoundError extends IoWalletError {
+  static get code(): "ERR_IO_WALLET_INSTANCE_NOT_FOUND" {
+    return "ERR_IO_WALLET_INSTANCE_NOT_FOUND";
+  }
+
+  code = "ERR_IO_WALLET_INSTANCE_NOT_FOUND";
+
+  claim: string;
+  reason: string;
+
+  constructor(message: string, claim: string, reason: string = "unspecified") {
+    super(serializeAttrs({ message, claim, reason }));
+    this.reason = reason;
+    this.claim = claim;
   }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -86,14 +86,26 @@ export class WalletInstanceAttestationIssuingError extends IoWalletError {
   /** Reason code for the validation failure. */
   reason: string;
 
+  /** HTTP status code */
+  statusCode: number;
+
   constructor(
     message: string,
     claim: string = "unspecified",
-    reason: string = "unspecified"
+    reason: string = "unspecified",
+    statusCode: number
   ) {
-    super(serializeAttrs({ message, claim, reason }));
+    super(
+      serializeAttrs({
+        message,
+        claim,
+        reason,
+        statusCode: statusCode.toString(),
+      })
+    );
     this.claim = claim;
     this.reason = reason;
+    this.statusCode = statusCode;
   }
 }
 
@@ -251,13 +263,25 @@ export class WalletProviderResponseError extends IoWalletError {
   /** Reason code for the validation failure. */
   reason: string;
 
+  /** HTTP status code */
+  statusCode: number;
+
   constructor(
     message: string,
     claim: string = "unspecified",
-    reason: string = "unspecified"
+    reason: string = "unspecified",
+    statusCode: number
   ) {
-    super(serializeAttrs({ message, claim, reason }));
+    super(
+      serializeAttrs({
+        message,
+        claim,
+        reason,
+        statusCode: statusCode.toString(),
+      })
+    );
     this.claim = claim;
     this.reason = reason;
+    this.statusCode = statusCode;
   }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -70,6 +70,34 @@ export class ValidationFailed extends IoWalletError {
 }
 
 /**
+ * An error subclass thrown when validation fail
+ *
+ */
+export class WalletInstanceAttestationIssuingError extends IoWalletError {
+  static get code(): "ERR_IO_WALLET_INSTANCE_ATTESTATION_ISSUING_FAILED" {
+    return "ERR_IO_WALLET_INSTANCE_ATTESTATION_ISSUING_FAILED";
+  }
+
+  code = "ERR_IO_WALLET_INSTANCE_ATTESTATION_ISSUING_FAILED";
+
+  /** The Claim for which the validation failed. */
+  claim: string;
+
+  /** Reason code for the validation failure. */
+  reason: string;
+
+  constructor(
+    message: string,
+    claim: string = "unspecified",
+    reason: string = "unspecified"
+  ) {
+    super(serializeAttrs({ message, claim, reason }));
+    this.claim = claim;
+    this.reason = reason;
+  }
+}
+
+/**
  * An error subclass thrown when auth request decode fail
  *
  */

--- a/src/wallet-instance-attestation/issuing.ts
+++ b/src/wallet-instance-attestation/issuing.ts
@@ -136,7 +136,7 @@ const handleAttestationCreationError = (e: unknown) => {
   }
 
   throw new WalletInstanceAttestationIssuingError(
-    `Unable to obtain wallet instance attestation [response code: ${e.statusCode}]`,
+    `Unable to obtain wallet instance attestation [response status code: ${e.statusCode}]`,
     e.claim,
     e.reason
   );

--- a/src/wallet-instance-attestation/issuing.ts
+++ b/src/wallet-instance-attestation/issuing.ts
@@ -8,6 +8,7 @@ import {
   WalletProviderResponseError,
   WalletInstanceRevokedError,
   WalletInstanceNotFoundError,
+  WalletInstanceAttestationIssuingError,
 } from "../utils/errors";
 
 /**
@@ -134,5 +135,9 @@ const handleAttestationCreationError = (e: unknown) => {
     );
   }
 
-  throw e;
+  throw new WalletInstanceAttestationIssuingError(
+    `Unable to obtain wallet instance attestation [response code: ${e.statusCode}]`,
+    e.claim,
+    e.reason
+  );
 };

--- a/src/wallet-instance/index.ts
+++ b/src/wallet-instance/index.ts
@@ -1,14 +1,5 @@
-import { type CryptoContext } from "@pagopa/io-react-native-jwt";
 import { getWalletProviderClient } from "../client";
-import { getAttestation } from "../wallet-instance-attestation/issuing";
-import { type IntegrityContext } from "..";
-import { WalletInstanceAttestationIssuingError } from "../utils/errors";
-
-export enum WalletInstanceRecordState {
-  REGISTERED,
-  REVOKED,
-  NOT_FOUND,
-}
+import type { IntegrityContext } from "..";
 
 export async function createWalletInstance(context: {
   integrityContext: IntegrityContext;
@@ -35,32 +26,4 @@ export async function createWalletInstance(context: {
   });
 
   return hardwareKeyTag;
-}
-
-/**
- * Returns the remote state of the Wallet Instance, i.e. the Wallet Instance Record state.
- * This is useful to know whether the instance was revoked or registered.
- * @returns The Wallet Instance Record state
- */
-export async function getRemoteWalletInstanceState(context: {
-  wiaCryptoContext: CryptoContext;
-  integrityContext: IntegrityContext;
-  walletProviderBaseUrl: string;
-  appFetch?: GlobalFetch["fetch"];
-}): Promise<WalletInstanceRecordState> {
-  try {
-    // Try to get an attestation. The state of the wallet instance
-    // is determined by the HTTP status code of the attestation request.
-    await getAttestation(context);
-  } catch (e) {
-    if (e instanceof WalletInstanceAttestationIssuingError) {
-      if (e.statusCode === 403) return WalletInstanceRecordState.REVOKED;
-      if (e.statusCode === 404) return WalletInstanceRecordState.NOT_FOUND;
-    }
-
-    // Rethrow unexpected errors so the caller can handle them
-    throw e;
-  }
-
-  return WalletInstanceRecordState.REGISTERED;
 }

--- a/src/wallet-instance/index.ts
+++ b/src/wallet-instance/index.ts
@@ -1,5 +1,14 @@
+import { type CryptoContext } from "@pagopa/io-react-native-jwt";
 import { getWalletProviderClient } from "../client";
-import type { IntegrityContext } from "..";
+import { getAttestation } from "../wallet-instance-attestation/issuing";
+import { type IntegrityContext } from "..";
+import { WalletInstanceAttestationIssuingError } from "../utils/errors";
+
+export enum WalletInstanceRecordState {
+  REGISTERED,
+  REVOKED,
+  NOT_FOUND,
+}
 
 export async function createWalletInstance(context: {
   integrityContext: IntegrityContext;
@@ -26,4 +35,32 @@ export async function createWalletInstance(context: {
   });
 
   return hardwareKeyTag;
+}
+
+/**
+ * Returns the remote state of the Wallet Instance, i.e. the Wallet Instance Record state.
+ * This is useful to know whether the instance was revoked or registered.
+ * @returns The Wallet Instance Record state
+ */
+export async function getRemoteWalletInstanceState(context: {
+  wiaCryptoContext: CryptoContext;
+  integrityContext: IntegrityContext;
+  walletProviderBaseUrl: string;
+  appFetch?: GlobalFetch["fetch"];
+}): Promise<WalletInstanceRecordState> {
+  try {
+    // Try to get an attestation. The state of the wallet instance
+    // is determined by the HTTP status code of the attestation request.
+    await getAttestation(context);
+  } catch (e) {
+    if (e instanceof WalletInstanceAttestationIssuingError) {
+      if (e.statusCode === 403) return WalletInstanceRecordState.REVOKED;
+      if (e.statusCode === 404) return WalletInstanceRecordState.NOT_FOUND;
+    }
+
+    // Rethrow unexpected errors so the caller can handle them
+    throw e;
+  }
+
+  return WalletInstanceRecordState.REGISTERED;
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Added `WalletInstanceRevokedError`
- Added `WalletInstanceNotFoundError`
- Handle errors in `getAttestation`

#### Motivation and Context

When getting a Wallet Instance Attestation the server may respond with specific HTTP status codes that define the status of a Wallet Instance, i.e. revoked or not found.

The library now catches those status codes and maps them to more meaningful errors.

#### How Has This Been Tested?

The example application was run with a proxy to intercept responses and change the HTTP status code.