### PR TITLE
feat: [SIW-1255] Add issuer authentication

### DIFF
--- a/example/.env.example
+++ b/example/.env.example
@@ -1,1 +1,3 @@
 WALLET_PROVIDER_BASE_URL=https://walletprovider.example.org
+ISSUER_BASE_URL=https://issuer.example.org
+ISSUER_AUTH_TOKEN=IssuerAuthToken

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -1,4 +1,6 @@
 declare module "@env" {
   export const WALLET_PROVIDER_BASE_URL: string;
   export const GOOGLE_CLOUD_PROJECT_NUMBER: string;
+  export const ISSUER_BASE_URL: string;
+  export const ISSUER_AUTH_TOKEN: string;
 }

--- a/example/src/utils/fetch.ts
+++ b/example/src/utils/fetch.ts
@@ -1,9 +1,8 @@
 import { ISSUER_AUTH_TOKEN, ISSUER_BASE_URL } from "@env";
 
-function addAuthHeaders(
-  options: RequestInit,
-  authHeaders: Record<string, string>
-) {
+type AuthHeaders = Record<string, string>;
+
+function addAuthHeaders(options: RequestInit, authHeaders: AuthHeaders) {
   return {
     ...options,
     headers: {
@@ -16,7 +15,7 @@ function addAuthHeaders(
 export default function appFetch(request: RequestInfo, options: RequestInit) {
   const requestUrl =
     typeof request === "string" ? new URL(request) : new URL(request.url);
-  const authHeaders: Record<string, string> =
+  const authHeaders: AuthHeaders =
     requestUrl.origin === new URL(ISSUER_BASE_URL).origin
       ? { Authorization: `${ISSUER_AUTH_TOKEN}` }
       : {};

--- a/example/src/utils/fetch.ts
+++ b/example/src/utils/fetch.ts
@@ -16,9 +16,10 @@ function addAuthHeaders(
 export default function appFetch(request: RequestInfo, options: RequestInit) {
   const requestUrl =
     typeof request === "string" ? new URL(request) : new URL(request.url);
-  const authHeaders = requestUrl.origin === issuerBaseUrl.origin 
-    ? { Authorization: `Bearer ${issuerAuthToken}` } 
-    : {};
+  const authHeaders: Record<string, string> =
+    requestUrl.origin === new URL(ISSUER_BASE_URL).origin
+      ? { Authorization: `${ISSUER_AUTH_TOKEN}` }
+      : {};
 
   return fetch(request, addAuthHeaders(options, authHeaders));
 }

--- a/example/src/utils/fetch.ts
+++ b/example/src/utils/fetch.ts
@@ -1,8 +1,5 @@
 import { ISSUER_AUTH_TOKEN, ISSUER_BASE_URL } from "@env";
 
-const issuerBaseUrl = new URL(ISSUER_BASE_URL);
-const issuerAuthToken = ISSUER_AUTH_TOKEN;
-
 function addAuthHeaders(
   options: RequestInit,
   authHeaders: Record<string, string>
@@ -22,9 +19,9 @@ export default function appFetch(request: RequestInfo, options: RequestInit) {
   let authHeaders: Record<string, string> = {};
 
   // Add the authentication header only if I am contacting the issuer URL
-  if (requestUrl.origin === issuerBaseUrl.origin) {
+  if (requestUrl.origin === new URL(ISSUER_BASE_URL).origin) {
     authHeaders = {
-      Authorization: `${issuerAuthToken}`,
+      Authorization: `${ISSUER_AUTH_TOKEN}`,
     };
   }
 

--- a/example/src/utils/fetch.ts
+++ b/example/src/utils/fetch.ts
@@ -1,0 +1,32 @@
+import { ISSUER_AUTH_TOKEN, ISSUER_BASE_URL } from "@env";
+
+const issuerBaseUrl = new URL(ISSUER_BASE_URL);
+const issuerAuthToken = ISSUER_AUTH_TOKEN;
+
+function addAuthHeaders(
+  options: RequestInit,
+  authHeaders: Record<string, string>
+) {
+  return {
+    ...options,
+    headers: {
+      ...options.headers,
+      ...authHeaders,
+    },
+  };
+}
+
+export default function appFetch(request: RequestInfo, options: RequestInit) {
+  const requestUrl =
+    typeof request === "string" ? new URL(request) : new URL(request.url);
+  let authHeaders: Record<string, string> = {};
+
+  // Add the authentication header only if I am contacting the issuer URL
+  if (requestUrl.origin === issuerBaseUrl.origin) {
+    authHeaders = {
+      Authorization: `${issuerAuthToken}`,
+    };
+  }
+
+  return fetch(request, addAuthHeaders(options, authHeaders));
+}

--- a/example/src/utils/fetch.ts
+++ b/example/src/utils/fetch.ts
@@ -1,6 +1,8 @@
 import { ISSUER_AUTH_TOKEN, ISSUER_BASE_URL } from "@env";
 
-type AuthHeaders = Record<string, string>;
+interface AuthHeaders {
+  Authorization?: string;
+}
 
 function addAuthHeaders(options: RequestInit, authHeaders: AuthHeaders) {
   return {

--- a/example/src/utils/fetch.ts
+++ b/example/src/utils/fetch.ts
@@ -16,14 +16,9 @@ function addAuthHeaders(
 export default function appFetch(request: RequestInfo, options: RequestInit) {
   const requestUrl =
     typeof request === "string" ? new URL(request) : new URL(request.url);
-  let authHeaders: Record<string, string> = {};
-
-  // Add the authentication header only if I am contacting the issuer URL
-  if (requestUrl.origin === new URL(ISSUER_BASE_URL).origin) {
-    authHeaders = {
-      Authorization: `${ISSUER_AUTH_TOKEN}`,
-    };
-  }
+  const authHeaders = requestUrl.origin === issuerBaseUrl.origin 
+    ? { Authorization: `Bearer ${issuerAuthToken}` } 
+    : {};
 
   return fetch(request, addAuthHeaders(options, authHeaders));
 }


### PR DESCRIPTION
It introduces a utility within the example app to generate a `fetch` function that adds the **authentication token** read by the `env` to the **headers** of the request to the issuer.