### PR TITLE
fix: [SIW-1273] Fix dev-proxy and rename env variables

### DIFF
--- a/example/.env.example
+++ b/example/.env.example
@@ -1,3 +1,3 @@
-WALLET_PROVIDER_BASE_URL=https://walletprovider.example.org
-ISSUER_BASE_URL=https://issuer.example.org
-ISSUER_AUTH_TOKEN=IssuerAuthToken
+WALLET_PROVIDER_BASE_URL='example' # Base URL for the Wallet provider
+WALLET_PID_PROVIDER_BASE_URL='example' # Base URL for the PID provider
+WALLET_PID_PROVIDER_AUTH_TOKEN='example' # Auth token for the PID provider. Used only for preprod.

--- a/example/dev-proxy/app.py
+++ b/example/dev-proxy/app.py
@@ -15,9 +15,8 @@ USER_ID = config('USER_ID')
 APP_KEY = config('APP_KEY')
 
 @app.route('/', defaults={'path': ''}, methods=["GET", "POST", "PUT"])
-@app.route('/<path>', methods=["GET", "POST", "PUT"])
+@app.route('/api/v1/wallet/<path>', methods=["GET", "POST", "PUT"])
 def redirect_to_API_HOST(path):  #NOTE var :path will be unused as all path we need will be read from :request ie from flask import request
-
     # exclude 'host' header
     request_headers = {k:v for k,v in request.headers if k.lower() != 'host'}
     request_headers["x-iowallet-user-id"] = USER_ID

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -1,6 +1,6 @@
 declare module "@env" {
   export const WALLET_PROVIDER_BASE_URL: string;
   export const GOOGLE_CLOUD_PROJECT_NUMBER: string;
-  export const ISSUER_BASE_URL: string;
-  export const ISSUER_AUTH_TOKEN: string;
+  export const WALLET_PID_PROVIDER_BASE_URL: string;
+  export const WALLET_PID_PROVIDER_AUTH_TOKEN: string;
 }

--- a/example/src/utils/fetch.ts
+++ b/example/src/utils/fetch.ts
@@ -1,4 +1,7 @@
-import { ISSUER_AUTH_TOKEN, ISSUER_BASE_URL } from "@env";
+import {
+  WALLET_PID_PROVIDER_AUTH_TOKEN,
+  WALLET_PID_PROVIDER_BASE_URL,
+} from "@env";
 
 interface AuthHeaders {
   Authorization?: string;
@@ -18,8 +21,8 @@ export default function appFetch(request: RequestInfo, options: RequestInit) {
   const requestUrl =
     typeof request === "string" ? new URL(request) : new URL(request.url);
   const authHeaders: AuthHeaders =
-    requestUrl.origin === new URL(ISSUER_BASE_URL).origin
-      ? { Authorization: `${ISSUER_AUTH_TOKEN}` }
+    requestUrl.origin === new URL(WALLET_PID_PROVIDER_BASE_URL).origin
+      ? { Authorization: `${WALLET_PID_PROVIDER_AUTH_TOKEN}` }
       : {};
 
   return fetch(request, addAuthHeaders(options, authHeaders));


### PR DESCRIPTION
As it is structured, the dev-proxy only works by proxing the requests that arrive on the first path (e.g. `/path`) but does not manage multipaths (e.g. `/api/v1/path`). Since our simulated backend will have to be called on a different base path (`/api/v1/wallet`) this **basepath** has also been added to the dev server.

Furthermore, the names of the environment variables have been changed in accordance with what has already been defined in other PRs.