### PR TITLE
fix: [SIW-1324] Add prod configuration

### DIFF
--- a/example/.env.example
+++ b/example/.env.example
@@ -4,3 +4,5 @@ WALLET_EAA_PROVIDER_BASE_URL='example' # Base URL for the EAA provider
 REDIRECT_URI='example' # Redirect URI used to detect a successful authentication. On Android it must be registered in the AndroidManifest.xml
 GOOGLE_CLOUD_PROJECT_NUMBER='1234567890' # Google Cloud Project Number for the Google Play Integrity API
 CIE_PIN='123456' # Pin of CIE to use with L3 login
+CIE_UAT='true' #If you want to use CIE with uat environment or prod
+SPID_IDPHINT='https://demo.spid.gov.it' # idphint to use with SPID

--- a/example/ios/IoReactNativeWalletExample.xcodeproj/project.pbxproj
+++ b/example/ios/IoReactNativeWalletExample.xcodeproj/project.pbxproj
@@ -612,7 +612,10 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 			};
@@ -682,7 +685,10 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,10 +4,9 @@ import React from "react";
 import "react-native-url-polyfill/auto";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import { type IntegrityContext } from "@pagopa/io-react-native-wallet";
-import { IdpHint } from "./scenarios/get-pid";
 import type { CryptoContext } from "@pagopa/io-react-native-jwt";
 import TestCieL3Scenario from "./scenarios/component/TestCieL3Scenario";
-import { CIE_PIN } from "@env";
+import { CIE_PIN, CIE_UAT, SPID_IDPHINT } from "@env";
 
 /**
  * PidContext is a tuple containing the PID and its crypto context.
@@ -15,12 +14,19 @@ import { CIE_PIN } from "@env";
  */
 export type PidContext = { pid: string; pidCryptoContext: CryptoContext };
 
+const CIE_PROD_IDPHINT =
+  "https://idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO";
+
+const CIE_UAT_IDPHINT =
+  "https://collaudo.idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO";
+
+export const isCieUat = CIE_UAT === "true" || CIE_UAT === "1";
+
 export default function App() {
   const [integrityContext, setIntegrityContext] = React.useState<
     IntegrityContext | undefined
   >();
   const [pidContext, setPidContext] = React.useState<PidContext>();
-
   return (
     <SafeAreaProvider>
       <SafeAreaView>
@@ -45,7 +51,7 @@ export default function App() {
               title="Get PID (SPID DEMO)"
               scenario={scenarios.getPid(
                 integrityContext!,
-                IdpHint.SPID,
+                SPID_IDPHINT,
                 setPidContext
               )}
               disabled={!integrityContext}
@@ -54,7 +60,7 @@ export default function App() {
               title="Get PID (CIE DEMO)"
               scenario={scenarios.getPid(
                 integrityContext!,
-                IdpHint.CIE,
+                isCieUat ? CIE_UAT_IDPHINT : CIE_PROD_IDPHINT,
                 setPidContext
               )}
               disabled={!integrityContext}
@@ -63,7 +69,10 @@ export default function App() {
               title="Get PID (CIE+PIN)"
               integrityContext={integrityContext!}
               ciePin={CIE_PIN}
+              isCieUat={isCieUat}
+              idpHint={isCieUat ? CIE_UAT_IDPHINT : CIE_PROD_IDPHINT}
               disabled={!integrityContext}
+              setPid={setPidContext}
             />
             <TestScenario
               title="Get credential (mDL)"

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -5,4 +5,6 @@ declare module "@env" {
   export const REDIRECT_URI: string;
   export const GOOGLE_CLOUD_PROJECT_NUMBER: string;
   export const CIE_PIN: string;
+  export const CIE_UAT: string;
+  export const SPID_IDPHINT: string;
 }

--- a/example/src/scenarios/get-pid.ts
+++ b/example/src/scenarios/get-pid.ts
@@ -18,21 +18,15 @@ import { Alert } from "react-native";
 import type { PidContext } from "../App";
 
 /**
- * Example of IdpHint values which currently support DEMO environments
- */
-export enum IdpHint {
-  CIE = "https://collaudo.idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO",
-  SPID = "https://demo.spid.gov.it",
-}
-
-/**
  * Callback used to set the PID and its crypto context in the app state which is later used to obtain a credential
  */
-type PidSetter = React.Dispatch<React.SetStateAction<PidContext | undefined>>;
+export type PidSetter = React.Dispatch<
+  React.SetStateAction<PidContext | undefined>
+>;
 
 export default (
     integrityContext: IntegrityContext,
-    idphint: IdpHint = IdpHint.SPID,
+    idphint: string,
     setPid: PidSetter
   ) =>
   async () => {
@@ -50,13 +44,11 @@ export default (
         });
 
       // Create identification context only for SPID
-      const authorizationContext =
-        idphint === IdpHint.SPID
-          ? {
-              authorize: openAuthenticationSession,
-            }
-          : undefined;
-
+      const authorizationContext = idphint.includes("servizicie")
+        ? undefined
+        : {
+            authorize: openAuthenticationSession,
+          };
       /*
        * Create credential crypto context for the PID
        * WARNING: The eID keytag must be persisted and later used when requesting a credential which requires a eID presentation

--- a/src/cie/manager.ts
+++ b/src/cie/manager.ts
@@ -34,10 +34,10 @@ export const startCieAndroid = (
         onEvent(CieEvent.waiting_card);
       })
       .catch(onError);
-  } catch {
+  } catch (e) {
     onError(
       new CieError({
-        message: "Unable to start CIE NFC manager on iOS",
+        message: `Unable to start CIE NFC manager on Android: ${e}`,
         type: CieErrorType.NFC_ERROR,
       })
     );
@@ -70,10 +70,10 @@ export const startCieiOS = async (
         onEvent(CieEvent.waiting_card);
       })
       .catch(onError);
-  } catch {
+  } catch (e) {
     onError(
       new CieError({
-        message: "Unable to start CIE NFC manager on Android",
+        message: `Unable to start CIE NFC manager on iOS: ${e}`,
         type: CieErrorType.NFC_ERROR,
       })
     );


### PR DESCRIPTION
Adds the configuration to use dev or prod environment on the sample app by directly configuring the `.env`.

Now it is possible to set whether to use the `UAT` environment for CIE and specify the `SPID_IDPHINT` to use. Therefore it is not necessary to indicate the CIE idphint since it is known.

Example:
```
CIE_UAT='false'
SPID_IDPHINT='https://posteid.poste.it'
```

It also introduces some minor fixes.