### PR TITLE
fix: Fix dPoP

### DIFF
--- a/example/src/scenarios/component/TestCieL3Scenario.tsx
+++ b/example/src/scenarios/component/TestCieL3Scenario.tsx
@@ -194,7 +194,7 @@ export default function TestCieL3Scenario({
       await generate(credentialKeyTag);
       const credentialCryptoContext = createCryptoContextFor(credentialKeyTag);
 
-      const { accessToken, tokenRequestSignedDPop } =
+      const { accessToken, dPoPContext } =
         await Credential.Issuance.authorizeAccess(
           issuerConf,
           code,
@@ -212,7 +212,7 @@ export default function TestCieL3Scenario({
         accessToken,
         clientId,
         credentialDefinition,
-        tokenRequestSignedDPop,
+        dPoPContext,
         {
           credentialCryptoContext,
         }

--- a/example/src/scenarios/get-crendential.ts
+++ b/example/src/scenarios/get-crendential.ts
@@ -82,7 +82,7 @@ export default (integrityContext: IntegrityContext, pidContext: PidContext) =>
           { wiaCryptoContext, pidCryptoContext, pid, walletInstanceAttestation }
         );
 
-      const { accessToken, tokenRequestSignedDPop } =
+      const { accessToken, dPoPContext } =
         await Credential.Issuance.authorizeAccess(
           issuerConf,
           code,
@@ -102,7 +102,7 @@ export default (integrityContext: IntegrityContext, pidContext: PidContext) =>
         accessToken,
         clientId,
         credentialDefinition,
-        tokenRequestSignedDPop,
+        dPoPContext,
         {
           credentialCryptoContext,
           appFetch,

--- a/example/src/scenarios/get-pid.ts
+++ b/example/src/scenarios/get-pid.ts
@@ -96,7 +96,7 @@ export default (
           authorizationContext
         );
 
-      const { accessToken, tokenRequestSignedDPop } =
+      const { accessToken, dPoPContext } =
         await Credential.Issuance.authorizeAccess(
           issuerConf,
           code,
@@ -116,7 +116,7 @@ export default (
         accessToken,
         clientId,
         credentialDefinition,
-        tokenRequestSignedDPop,
+        dPoPContext,
         {
           credentialCryptoContext,
           appFetch,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-wallet",
-  "version": "0.16.0",
+  "version": "0.15.4",
   "description": "Provide data structures, helpers and API for IO Wallet",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-wallet",
-  "version": "0.15.3",
+  "version": "0.16.0",
   "description": "Provide data structures, helpers and API for IO Wallet",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/credential/issuance/05-authorize-access.ts
+++ b/src/credential/issuance/05-authorize-access.ts
@@ -7,7 +7,7 @@ import uuid from "react-native-uuid";
 import { createPopToken } from "../../utils/pop";
 import * as WalletInstanceAttestation from "../../wallet-instance-attestation";
 import type { CryptoContext } from "@pagopa/io-react-native-jwt";
-import { ASSERTION_TYPE } from "./const";
+import { ASSERTION_TYPE, DPOP_KET_TAG } from "./const";
 import { TokenResponse } from "./types";
 import { ValidationFailed } from "../../utils/errors";
 import type { CompleteUserAuthorizationWithQueryMode } from "./04-complete-user-authorization";
@@ -64,9 +64,7 @@ export const authorizeAccess: AuthorizeAccess = async (
     .payload.cnf.jwk.kid;
 
   const tokenUrl = issuerConf.oauth_authorization_server.token_endpoint;
-  // Use an ephemeral key to be destroyed after use
 
-  const DPOP_KET_TAG = "dpopd";
   try {
     await generate(DPOP_KET_TAG);
   } catch {

--- a/src/credential/issuance/05-authorize-access.ts
+++ b/src/credential/issuance/05-authorize-access.ts
@@ -1,7 +1,7 @@
 import { hasStatus, type Out } from "../../utils/misc";
 import type { EvaluateIssuerTrust } from "./02-evaluate-issuer-trust";
 import type { StartUserAuthorization } from "./03-start-user-authorization";
-import { withEphemeralKey } from "../../utils/crypto";
+import { createCryptoContextFor } from "../../utils/crypto";
 import { createDPopToken } from "../../utils/dpop";
 import uuid from "react-native-uuid";
 import { createPopToken } from "../../utils/pop";
@@ -11,6 +11,7 @@ import { ASSERTION_TYPE } from "./const";
 import { TokenResponse } from "./types";
 import { ValidationFailed } from "../../utils/errors";
 import type { CompleteUserAuthorizationWithQueryMode } from "./04-complete-user-authorization";
+import { generate } from "@pagopa/io-react-native-crypto";
 
 export type AuthorizeAccess = (
   issuerConf: Out<EvaluateIssuerTrust>["issuerConf"],
@@ -23,7 +24,7 @@ export type AuthorizeAccess = (
     appFetch?: GlobalFetch["fetch"];
     wiaCryptoContext: CryptoContext;
   }
-) => Promise<{ accessToken: TokenResponse; tokenRequestSignedDPop: string }>;
+) => Promise<{ accessToken: TokenResponse; dPoPContext: CryptoContext }>;
 
 /**
  * Creates and sends the DPoP Proof JWT to be presented with the authorization code to the /token endpoint of the authorization server
@@ -64,17 +65,23 @@ export const authorizeAccess: AuthorizeAccess = async (
 
   const tokenUrl = issuerConf.oauth_authorization_server.token_endpoint;
   // Use an ephemeral key to be destroyed after use
-  const tokenRequestSignedDPop = await withEphemeralKey(
-    async (ephimeralContext) => {
-      return await createDPopToken(
-        {
-          htm: "POST",
-          htu: tokenUrl,
-          jti: `${uuid.v4()}`,
-        },
-        ephimeralContext
-      );
-    }
+
+  const DPOP_KET_TAG = "dpopd";
+  try {
+    await generate(DPOP_KET_TAG);
+  } catch {
+    console.log("DPoP key already exist");
+  }
+
+  const dPoPContext = createCryptoContextFor(DPOP_KET_TAG);
+
+  const tokenRequestSignedDPop = await createDPopToken(
+    {
+      htm: "POST",
+      htu: tokenUrl,
+      jti: `${uuid.v4()}`,
+    },
+    dPoPContext
   );
 
   const signedWiaPoP = await createPopToken(
@@ -113,5 +120,5 @@ export const authorizeAccess: AuthorizeAccess = async (
     throw new ValidationFailed(tokenRes.error.message);
   }
 
-  return { accessToken: tokenRes.data, tokenRequestSignedDPop };
+  return { accessToken: tokenRes.data, dPoPContext };
 };

--- a/src/credential/issuance/06-obtain-credential.ts
+++ b/src/credential/issuance/06-obtain-credential.ts
@@ -12,6 +12,8 @@ import { CredentialResponse } from "./types";
 
 import { createDPopToken } from "../../utils/dpop";
 import uuid from "react-native-uuid";
+import { deleteKey } from "@pagopa/io-react-native-crypto";
+import { DPOP_KET_TAG } from "./const";
 
 export type ObtainCredential = (
   issuerConf: Out<EvaluateIssuerTrust>["issuerConf"],
@@ -67,7 +69,7 @@ export const obtainCredential: ObtainCredential = async (
   accessToken,
   clientId,
   credentialDefinition,
-  ephemeralContext,
+  dPoPContext,
   context
 ) => {
   const { credentialCryptoContext, appFetch = fetch } = context;
@@ -120,9 +122,10 @@ export const obtainCredential: ObtainCredential = async (
       jti: `${uuid.v4()}`,
       ath: await sha256ToBase64(accessToken.access_token),
     },
-    ephemeralContext
+    dPoPContext
   );
 
+  deleteKey(DPOP_KET_TAG);
   const credentialRes = await appFetch(credentialUrl, {
     method: "POST",
     headers: {

--- a/src/credential/issuance/06-obtain-credential.ts
+++ b/src/credential/issuance/06-obtain-credential.ts
@@ -125,7 +125,7 @@ export const obtainCredential: ObtainCredential = async (
     dPoPContext
   );
 
-  deleteKey(DPOP_KET_TAG);
+  await deleteKey(DPOP_KET_TAG);
   const credentialRes = await appFetch(credentialUrl, {
     method: "POST",
     headers: {

--- a/src/credential/issuance/const.ts
+++ b/src/credential/issuance/const.ts
@@ -2,6 +2,8 @@ import * as z from "zod";
 export const ASSERTION_TYPE =
   "urn:ietf:params:oauth:client-assertion-type:jwt-client-attestation";
 
+export const DPOP_KET_TAG = `dpop`;
+
 export type SupportedCredentialFormat = z.infer<
   typeof SupportedCredentialFormat
 >;


### PR DESCRIPTION
Fixes the use of DPoP and adds management of the dPoP crypto context. It should not introduce breaking change.
An ephemeral key is no longer used for each DPoP but the same key is recycled for each obtainment flow. Only at the end of obtaining the key is it deleted. If the flow is not successful, the same key can be reused.