### PR TITLE
build: Align Podfile.lock

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -388,8 +388,6 @@ PODS:
   - React-jsinspector (0.72.14)
   - React-logger (0.72.14):
     - glog
-  - react-native-cie (1.3.0):
-    - React
   - react-native-safe-area-context (4.9.0):
     - React-Core
   - react-native-webview (13.10.5):
@@ -561,7 +559,6 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
-  - "react-native-cie (from `../node_modules/@pagopa/react-native-cie`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
@@ -653,8 +650,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
-  react-native-cie:
-    :path: "../node_modules/@pagopa/react-native-cie"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-webview:
@@ -735,7 +730,6 @@ SPEC CHECKSUMS:
   React-jsiexecutor: e9a70be9304ef2e66eeebac35710f958b076dc14
   React-jsinspector: 275d9f80210f15f0af9a4b7fd5683fab9738e28e
   React-logger: 8da4802de77a0eb62512396ad6bb1769904c2f0e
-  react-native-cie: bf1cff366d2b2eeaeaf53e7425e47d15d3e1413c
   react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
   react-native-webview: f1745c33e5278e7c58ff7b8aff48dbb801395269
   React-NativeModulesApple: 3107f777453f953906d9ba9dc5f8cbd91a6ef913


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
This PR aligns the `Podfile.lock` of the iOS project.
<!--- Describe your changes in detail -->

#### Motivation and Context
Each time you run a `pod install` while cloning this repo, the `react-native-cie` dependency gets removed. This is intended because we have a script in our `package.json` to install and remove that package when needed. However we mistakenly committed the `Podfile.lock` after running the script which installs it.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
N/A
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
N/A
<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
