### PR TITLE
feat: [SIW-1439] Add Disability Card scenario to the example app

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,12 +1,12 @@
-import { ScrollView } from "react-native";
-import scenarios, { TestScenario } from "./scenarios";
-import React from "react";
-import "react-native-url-polyfill/auto";
-import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
-import { type IntegrityContext } from "@pagopa/io-react-native-wallet";
-import type { CryptoContext } from "@pagopa/io-react-native-jwt";
-import TestCieL3Scenario from "./scenarios/component/TestCieL3Scenario";
 import { CIE_PIN, CIE_UAT, SPID_IDPHINT } from "@env";
+import type { CryptoContext } from "@pagopa/io-react-native-jwt";
+import { type IntegrityContext } from "@pagopa/io-react-native-wallet";
+import React from "react";
+import { ScrollView } from "react-native";
+import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
+import "react-native-url-polyfill/auto";
+import scenarios, { TestScenario } from "./scenarios";
+import TestCieL3Scenario from "./scenarios/component/TestCieL3Scenario";
 
 /**
  * PidContext is a tuple containing the PID and its crypto context.
@@ -75,8 +75,21 @@ export default function App() {
               setPid={setPidContext}
             />
             <TestScenario
-              title="Get credential (mDL)"
-              scenario={scenarios.getCredential(integrityContext!, pidContext!)}
+              title="Get credential (MDL)"
+              scenario={scenarios.getCredential(
+                integrityContext!,
+                pidContext!,
+                "MDL"
+              )}
+              disabled={!integrityContext || !pidContext}
+            />
+            <TestScenario
+              title="Get credential (DC)"
+              scenario={scenarios.getCredential(
+                integrityContext!,
+                pidContext!,
+                "EuropeanDisabilityCard"
+              )}
               disabled={!integrityContext || !pidContext}
             />
           </>

--- a/example/src/scenarios/get-crendential.ts
+++ b/example/src/scenarios/get-crendential.ts
@@ -16,7 +16,11 @@ import { Alert } from "react-native";
 import type { PidContext } from "../App";
 import appFetch from "../utils/fetch";
 
-export default (integrityContext: IntegrityContext, pidContext: PidContext) =>
+export default (
+    integrityContext: IntegrityContext,
+    pidContext: PidContext,
+    type: string
+  ) =>
   async () => {
     try {
       const { pid, pidCryptoContext } = pidContext;
@@ -42,7 +46,7 @@ export default (integrityContext: IntegrityContext, pidContext: PidContext) =>
       // Start the issuance flow
       const startFlow: Credential.Issuance.StartFlow = () => ({
         issuerUrl: WALLET_EAA_PROVIDER_BASE_URL,
-        credentialType: "MDL",
+        credentialType: type,
       });
 
       const { issuerUrl, credentialType } = startFlow();


### PR DESCRIPTION
#### List of Changes

- Added `type` parameter to `get-credential` scenario
- Added Disability Card issuance button to the example app

#### Motivation and Context

This PR introduces the ability to obtain a Disability Card credential with the example app

#### How Has This Been Tested?

Test the DC scenario and obtain a Disability Card credential 

#### Screenshots (if appropriate):

N/A

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
