### PR TITLE
fix: [SIW-1483] Add listener removal when authenticating with query mode

### DIFF
--- a/src/credential/issuance/04-complete-user-authorization.ts
+++ b/src/credential/issuance/04-complete-user-authorization.ts
@@ -117,9 +117,10 @@ export const completeUserAuthorizationWithQueryMode: CompleteUserAuthorizationWi
         120
       );
 
-      await Promise.all([openAuthUrlInBrowser, unitAuthRedirectIsNotUndefined]);
-
-      Linking.removeSubscription(sub);
+      await Promise.all([
+        openAuthUrlInBrowser,
+        unitAuthRedirectIsNotUndefined,
+      ]).finally(() => Linking.removeSubscription(sub));
 
       if (authRedirectUrl === undefined) {
         throw new AuthorizationError("Invalid authentication redirect url");

--- a/src/credential/issuance/04-complete-user-authorization.ts
+++ b/src/credential/issuance/04-complete-user-authorization.ts
@@ -100,7 +100,7 @@ export const completeUserAuthorizationWithQueryMode: CompleteUserAuthorizationWi
         });
     } else {
       // handler for redirectUri
-      Linking.addEventListener("url", ({ url }) => {
+      const sub = Linking.addEventListener("url", ({ url }) => {
         if (url.includes(redirectUri)) {
           authRedirectUrl = url;
         }
@@ -118,6 +118,8 @@ export const completeUserAuthorizationWithQueryMode: CompleteUserAuthorizationWi
       );
 
       await Promise.all([openAuthUrlInBrowser, unitAuthRedirectIsNotUndefined]);
+
+      Linking.removeSubscription(sub);
 
       if (authRedirectUrl === undefined) {
         throw new AuthorizationError("Invalid authentication redirect url");


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds the listener removal when authenticating with query mode as this cause a double callback call when logging twice.
#### List of Changes

<!--- Describe your changes in detail -->
- Save the `EmitterSubscription` and remove it after waiting in the `Promise.all` in both success and failure cases;
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Check for regressions while obtaining a PID issuance with CieID.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
