### PR TITLE
chore: Release v0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-wallet",
-  "version": "0.15.4",
+  "version": "0.16.0",
   "description": "Provide data structures, helpers and API for IO Wallet",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
This PR bumps the package version to `v0.16.0`.