### PR TITLE
fix: [SIW-1516] Loading spinner not visibile when creating a wallet instance

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -531,7 +531,7 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - React-RCTImage
-  - RNSVG (15.6.0):
+  - RNSVG (15.5.0):
     - React-Core
   - SocketRocket (0.6.1)
   - SwiftCBOR (0.4.7)
@@ -806,7 +806,7 @@ SPEC CHECKSUMS:
   RNReactNativeHapticFeedback: e115bb12d05ced2aba090123e2690978507811ca
   RNReanimated: 1896df448c213a64e98cf3f796e4105bbfab41a2
   RNScreens: 284fcee9d8d4648851fdb85dd0e200daebedcc14
-  RNSVG: 5da7a24f31968ec74f0b091e3440080f347e279b
+  RNSVG: b986585e367f4a49d8aa43065066cc9c290b3d9b
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   SwiftCBOR: 465775bed0e8bac7bfb8160bcf7b95d7f75971e4
   Yoga: c32e0be1a17f8f1f0e633a3122f7666441f52c82

--- a/example/src/screens/WalletInstanceScreen.tsx
+++ b/example/src/screens/WalletInstanceScreen.tsx
@@ -5,6 +5,7 @@ import TestScenario, {
   type TestScenarioProp,
 } from "../components/TestScenario";
 import {
+  instanceReset,
   selectHasInstanceKeyTag,
   selectInstanceAsyncStatus,
   selectInstanceKeyTag,
@@ -16,7 +17,7 @@ import {
 import { getAttestationThunk } from "../thunks/attestation";
 import { useDebugInfo } from "../hooks/useDebugInfo";
 import { IOVisualCostants, VSpacer } from "@pagopa/io-app-design-system";
-import { FlatList } from "react-native";
+import { Alert, FlatList } from "react-native";
 
 /**
  * Component (screen in a future PR) to test the wallet instance functionalities.
@@ -42,7 +43,29 @@ export const WalletInstanceScreen = () => {
     () => [
       {
         title: "Create Wallet Instance",
-        onPress: () => dispatch(createWalletInstanceThunk()),
+        onPress: () => {
+          if (hasIntegrityKeyTag) {
+            Alert.alert(
+              "Wallet instance already exits",
+              "This will reset the whole app state except the session",
+              [
+                {
+                  text: "Ok",
+                  onPress: () => {
+                    dispatch(instanceReset());
+                    dispatch(createWalletInstanceThunk());
+                  },
+                  style: "destructive",
+                },
+                {
+                  text: "Cancel",
+                  onPress: () => console.log("Cancel Pressed"),
+                  style: "cancel",
+                },
+              ]
+            );
+          }
+        },
         isLoading: instanceState.isLoading,
         hasError: instanceState.hasError,
         isDone: instanceState.isDone,

--- a/example/src/thunks/instance.ts
+++ b/example/src/thunks/instance.ts
@@ -6,7 +6,6 @@ import {
   generateIntegrityHardwareKeyTag,
   getIntegrityContext,
 } from "../utils/integrity";
-import { instanceReset } from "../store/reducers/instance";
 import { selectEnv } from "../store/reducers/environment";
 import { getEnv } from "../utils/environment";
 import { isAndroid } from "../utils/device";
@@ -16,9 +15,7 @@ import { isAndroid } from "../utils/device";
  */
 export const createWalletInstanceThunk = createAppAsyncThunk(
   "walletinstance/create",
-  async (_, { getState, dispatch }) => {
-    dispatch(instanceReset()); // This resets the whole instance state beside the session
-
+  async (_, { getState }) => {
     // Get env
     const env = selectEnv(getState());
     const { GOOGLE_CLOUD_PROJECT_NUMBER, WALLET_PROVIDER_BASE_URL } =


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Add alert when pressing `Create Wallet Instance` if a wallet instance already exists;
- Dispatch the instance reset action outside the thunk before creating a new one;
- [EXTRA] Update misaligned `Podfile.lock` caused by #130 
<!--- Describe your changes in detail -->

#### Motivation and Context
The loading spinner was not visible during the instance creation because the instance reset action was dispatched within the thunk. As a result, the instance's async state was reset to its initial state immediately after being set to loading, causing the spinner to disappear.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Try to create a wallet instance, the loading spinner should be visibile. Try to create it again and the app should show an alert. Then press "Ok" and the app should resets the whole state before creating a new instance.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
