### PR TITLE
fix: [SIW-1515] CIE L3 scenario DPoP key error in example apple

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -7,8 +7,8 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "pods": "pod-install --quiet",
-    "cie-ios:prod": "mv node_modules/@pagopa/react-native-cie/.ios node_modules/@pagopa/react-native-cie/ios && mv node_modules/@pagopa/react-native-cie/.react-native-cie.podspec node_modules/@pagopa/react-native-cie/react-native-cie.podspec && cd ios && pod install",
-    "cie-ios:dev": "mv node_modules/@pagopa/react-native-cie/ios node_modules/@pagopa/react-native-cie/.ios && mv node_modules/@pagopa/react-native-cie/react-native-cie.podspec node_modules/@pagopa/react-native-cie/.react-native-cie.podspec && cd ios && rm -rf Pods && pod install"
+    "cie-ios:prod": "mv node_modules/@pagopa/react-native-cie/.ios node_modules/@pagopa/react-native-cie/ios && mv node_modules/@pagopa/react-native-cie/.react-native-cie.podspec node_modules/@pagopa/react-native-cie/react-native-cie.podspec && cd ios && bundler exec pod install",
+    "cie-ios:dev": "mv node_modules/@pagopa/react-native-cie/ios node_modules/@pagopa/react-native-cie/.ios && mv node_modules/@pagopa/react-native-cie/react-native-cie.podspec node_modules/@pagopa/react-native-cie/.react-native-cie.podspec && cd ios && rm -rf Pods && bundler exec pod install"
   },
   "dependencies": {
     "@pagopa/io-app-design-system": "^1.43.0",

--- a/example/src/components/TestCieL3Scenario.tsx
+++ b/example/src/components/TestCieL3Scenario.tsx
@@ -68,7 +68,6 @@ export default function TestCieL3Scenario({
   };
 
   const handleOnError = (error: Cie.CieError) => {
-    console.log(error);
     dispatch(pidCiel3FlowReset());
     setModalVisible(false);
     Alert.alert(`❌ ${JSON.stringify(error)}`);

--- a/example/src/components/TestCieL3Scenario.tsx
+++ b/example/src/components/TestCieL3Scenario.tsx
@@ -68,6 +68,7 @@ export default function TestCieL3Scenario({
   };
 
   const handleOnError = (error: Cie.CieError) => {
+    console.log(error);
     dispatch(pidCiel3FlowReset());
     setModalVisible(false);
     Alert.alert(`❌ ${JSON.stringify(error)}`);
@@ -124,6 +125,7 @@ export default function TestCieL3Scenario({
       Alert.alert(`❌ Modal closed`);
     }
     setModalVisible(!isModalVisible);
+    dispatch(pidCiel3FlowReset());
   };
 
   const getBadge = useCallback((): Badge | undefined => {
@@ -194,6 +196,9 @@ export default function TestCieL3Scenario({
         >
           <View style={styles.modalContainer}>
             <Text style={styles.modalText}>{modalText}</Text>
+            <TouchableOpacity onPress={toggleModal}>
+              <Text style={styles.modalText}>Press to close</Text>
+            </TouchableOpacity>
             <View style={styles.webviewContainer}>
               <TouchableOpacity
                 style={styles.closeButton}

--- a/example/src/store/reducers/credential.ts
+++ b/example/src/store/reducers/credential.ts
@@ -5,7 +5,6 @@ import {
   getCredentialStatusAttestationThunk,
   getCredentialThunk,
 } from "../../thunks/credential";
-import { type PrepareCieL3FlowParamsThunkOutput } from "../../thunks/pidCieL3";
 import type {
   CredentialResult,
   RootState,
@@ -30,7 +29,6 @@ type CredentialState = {
     CredentialResult | undefined
   >;
   credentialsAsyncStatus: Record<SupportedCredentialsWithoutPid, AsyncStatus>;
-  pidCiel3FlowParams: PrepareCieL3FlowParamsThunkOutput | undefined;
   statusAttestation: Record<SupportedCredentialsWithoutPid, string | undefined>;
   statusAttAsyncStatus: Record<SupportedCredentialsWithoutPid, AsyncStatus>;
 };
@@ -47,7 +45,6 @@ const initialState: CredentialState = {
     EuropeanDisabilityCard: asyncStatusInitial,
     EuropeanHealthInsuranceCard: asyncStatusInitial,
   },
-  pidCiel3FlowParams: undefined,
   statusAttestation: {
     MDL: undefined,
     EuropeanDisabilityCard: undefined,

--- a/example/src/store/reducers/pid.ts
+++ b/example/src/store/reducers/pid.ts
@@ -52,6 +52,10 @@ const pidSlice = createSlice({
     pidCiel3FlowReset: (state) => ({
       ...state,
       pidCiel3FlowParams: initialState.pidCiel3FlowParams,
+      pidAsyncStatus: {
+        ...state.pidAsyncStatus,
+        cieL3: asyncStatusInitial,
+      },
     }),
   },
   extraReducers: (builder) => {
@@ -223,5 +227,5 @@ export const selectPidAsyncStatus =
  * @returns the CiE L3 flow params
  */
 export const selectPidCieL3FlowParams = (state: RootState) => {
-  return state.credential.pidCiel3FlowParams;
+  return state.pid.pidCiel3FlowParams;
 };

--- a/example/src/thunks/pidCieL3.ts
+++ b/example/src/thunks/pidCieL3.ts
@@ -183,7 +183,7 @@ export const continueCieL3FlowThunk = createAppAsyncThunk<
   const credentialCryptoContext = createCryptoContextFor(credentialKeyTag);
 
   // Create DPoP context for the whole issuance flow
-  regenerateCryptoKey(DPOP_KEYTAG);
+  await regenerateCryptoKey(DPOP_KEYTAG);
   const dPopCryptoContext = createCryptoContextFor(DPOP_KEYTAG);
 
   const { accessToken } = await Credential.Issuance.authorizeAccess(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Add `await` when generating DPoP crypto keys;
- Add button to close CIE L3 modal on iOS as well; 
- Remove `pidCiel3FlowParams` from `credential` reducer which was wrongly left there;
- Add async status reset when dispatching `pidCiel3FlowReset` action in order to reset the loading state; 
- Fix `selectPidCieL3FlowParams` which was wrongly pointing to the `credential` reducer instead of `pid` reducer;
- Update the CIE DEV/PRO scripts in `package.json` to use `bundler` to run `pod install` which is now the advised way to do it;
<!--- Describe your changes in detail -->

#### Motivation and Context
This PR fixes the CIE L3 scenario failure caused by a DPoP key error. The root cause was an unawaited promise, leading to subsequent code attempting to use a cryptographic key that hadn't been generated yet. 
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Test a CIE L3 flow. Remember to run `yarn cie-ios:prod` before testing it. If you are not using `bundler` then you can locally revert the changes made to `package.json`.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
