### PR TITLE
feat: [SIW-1558] Add not entiled error when requesting a credential

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -426,3 +426,39 @@ export class StatusAttestationError extends IoWalletError {
     this.reason = reason;
   }
 }
+
+/**
+ * Error subclass thrown when the citizen is not entitled to a credential.
+ */
+export class CredentialNotEntitledError extends IoWalletError {
+  static get code(): "CREDENTIAL_NOT_ENTITLED_ERROR" {
+    return "CREDENTIAL_NOT_ENTITLED_ERROR";
+  }
+
+  code = "CREDENTIAL_NOT_ENTITLED_ERROR";
+
+  reason: string;
+
+  constructor(message: string, reason: string = "unspecified") {
+    super(serializeAttrs({ message, reason }));
+    this.reason = reason;
+  }
+}
+
+/**
+ * Error subclass thrown when an error occurs while requesting a credential.
+ */
+export class CredentialRequestError extends IoWalletError {
+  static get code(): "CREDENTIAL_REQUEST_ERROR" {
+    return "CREDENTIAL_REQUEST_ERROR";
+  }
+
+  code = "CREDENTIAL_REQUEST_ERROR";
+
+  reason: string;
+
+  constructor(message: string, reason: string = "unspecified") {
+    super(serializeAttrs({ message, reason }));
+    this.reason = reason;
+  }
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -428,7 +428,7 @@ export class StatusAttestationError extends IoWalletError {
 }
 
 /**
- * Error subclass thrown when the citizen is not entitled to a credential.
+ * Error subclass thrown when the the user is not entitled to receive the requested credential.
  */
 export class CredentialNotEntitledError extends IoWalletError {
   static get code(): "CREDENTIAL_NOT_ENTITLED_ERROR" {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Adds a specific error `CredentialNotEntitledError` when the credential issuer returns `404` in response to the `/credential` request;
- Adds a generic error `CredentialRequestError` for generic errors.
<!--- Describe your changes in detail -->

#### Motivation and Context
This PR adds a specific error which is raised when `/credential` response contains a `404` code which indicates the user is not entitled to receive the requested credential.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
With a proxy map locally the `/credential` response to a `404` and check in the debug menu of the example app if the custom error is thrown.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
