### PR TITLE
chore: [SIW-1635] Handle 201 status code when obtaining credential

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -462,3 +462,21 @@ export class CredentialRequestError extends IoWalletError {
     this.reason = reason;
   }
 }
+
+/**
+ * Error subclass thrown when a credential cannot be issued immediately because it follows the async flow.
+ */
+export class CredentialIssuingNotSynchronousError extends IoWalletError {
+  static get code(): "CREDENTIAL_ISSUING_NOT_SYNCHRONOUS_ERROR" {
+    return "CREDENTIAL_ISSUING_NOT_SYNCHRONOUS_ERROR";
+  }
+
+  code = "CREDENTIAL_ISSUING_NOT_SYNCHRONOUS_ERROR";
+
+  reason: string;
+
+  constructor(message: string, reason: string = "unspecified") {
+    super(serializeAttrs({ message, reason }));
+    this.reason = reason;
+  }
+}


### PR DESCRIPTION
#### List of Changes

- Handled 201 status code in `obtainCredential`
- Created `CredentialIssuingNotSynchronousError`

#### Motivation and Context

This PR handle the 201 status code when invoking the `obtainCredential` function: this status code means the credential will be issued asynchronously, as per `IO-WALLET-DR-0021` design review.

Although the 201 status code is not an error, it has been handled as such in order to keep the return value of `obtainCredential` unchanged. Otherwise, the return value should differentiate between a requested credential and a full credential response.

#### How Has This Been Tested?

A proxy was used to force a 201 status code. 
