### PR TITLE
fix: [SIW-1679] Restore optional parameter to get all disclosures

### DIFF
--- a/src/credential/issuance/07-verify-and-parse-credential.ts
+++ b/src/credential/issuance/07-verify-and-parse-credential.ts
@@ -215,6 +215,8 @@ const verifyAndParseCredentialSdJwt: WithFormat<"vc+sd-jwt"> = async (
  * @param credential The encoded credential returned by {@link obtainCredential}
  * @param format The format of the credentual returned by {@link obtainCredential}
  * @param context.credentialCryptoContext The crypto context used to obtain the credential in {@link obtainCredential}
+ * @param context.ignoreMissingAttributes Skip error when attributes declared in the issuer configuration are not found within disclosures
+ * @param context.includeUndefinedAttributes Include attributes not explicitly declared in the issuer configuration
  * @returns A parsed credential with attributes in plain value
  * @throws {IoWalletError} If the credential signature is not verified with the Issuer key set
  * @throws {IoWalletError} If the credential is not bound to the provided user key

--- a/src/credential/issuance/07-verify-and-parse-credential.ts
+++ b/src/credential/issuance/07-verify-and-parse-credential.ts
@@ -13,7 +13,13 @@ export type VerifyAndParseCredential = (
   format: Out<ObtainCredential>["format"],
   context: {
     credentialCryptoContext: CryptoContext;
+    /**
+     * Do not throw an error when an attribute is not found within disclosures.
+     */
     ignoreMissingAttributes?: boolean;
+    /**
+     * Include attributes that are not explicitly mapped in the issuer configuration.
+     */
     includeUndefinedAttributes?: boolean;
   }
 ) => Promise<{ parsedCredential: ParsedCredential }>;

--- a/src/credential/issuance/07-verify-and-parse-credential.ts
+++ b/src/credential/issuance/07-verify-and-parse-credential.ts
@@ -181,7 +181,11 @@ const verifyAndParseCredentialSdJwt: WithFormat<"vc+sd-jwt"> = async (
   issuerConf,
   credential,
   _,
-  { credentialCryptoContext, ignoreMissingAttributes }
+  {
+    credentialCryptoContext,
+    ignoreMissingAttributes,
+    includeUndefinedAttributes,
+  }
 ) => {
   const decoded = await verifyCredentialSdJwt(
     credential,
@@ -192,7 +196,8 @@ const verifyAndParseCredentialSdJwt: WithFormat<"vc+sd-jwt"> = async (
   const parsedCredential = parseCredentialSdJwt(
     issuerConf.openid_credential_issuer.credential_configurations_supported,
     decoded,
-    ignoreMissingAttributes
+    ignoreMissingAttributes,
+    includeUndefinedAttributes
   );
 
   return { parsedCredential };

--- a/src/credential/issuance/README.md
+++ b/src/credential/issuance/README.md
@@ -39,6 +39,10 @@ graph TD;
 
 ## Mapped results
 
+### 201 Created (CredentialIssuingNotSynchronousError)
+
+A `201 Created` response is returned by the credential issuer when the request has been queued because the credential cannot be issued synchronously. The consumer should try to obtain the credential at a later time.
+
 ### 404 Not Found (CredentialNotEntitledError)
 
 A `404 Not Found` response is returned by the credential issuer when the authenticated user is not entitled to receive the requested credential.
@@ -175,12 +179,19 @@ const { credential, format } = await Credential.Issuance.obtainCredential(
   }
 );
 
-// Parse and verify the credential. The ignoreMissingAttributes flag must be set to false or omitted in production.
+/*
+ * Parse and verify the credential. The ignoreMissingAttributes flag must be set to false or omitted in production.
+ * WARNING: includeUndefinedAttributes should not be set to true in production in order to get only claims explicitly declared by the issuer.
+ */
 const { parsedCredential } = await Credential.Issuance.verifyAndParseCredential(
   issuerConf,
   credential,
   format,
-  { credentialCryptoContext, ignoreMissingAttributes: true }
+  {
+    credentialCryptoContext,
+    ignoreMissingAttributes: true,
+    includeUndefinedAttributes: false
+  }
 );
 
 return {
@@ -318,6 +329,6 @@ return {
 };
 ```
 
-The result of this flow is a row credential and a parsed credential which must be stored securely in the wallet along with its crypto key.
+The result of this flow is a raw credential and a parsed credential which must be stored securely in the wallet along with its crypto key.
 
 </details>


### PR DESCRIPTION
#### List of Changes

- Pass `includeUndefinedAttributes` to `parseCredentialSdJwt`.

#### Motivation and Context

Currently it is possible to pass `includeUndefinedAttributes` to `verifyAndParseCredential`, but that parameter is lost in the internal function invocations, so it is not possible to get disclosures/claims that are not explicitly supported in the entity configuration.

