### PR TITLE
fix: [SIW-1681] Change pattern to find the CIE authentication link

### DIFF
--- a/src/cie/component.tsx
+++ b/src/cie/component.tsx
@@ -12,6 +12,8 @@ import type {
 import { startCieAndroid, startCieiOS, type ContinueWithUrl } from "./manager";
 import { CieError, CieErrorType } from "./error";
 
+const AUTH_BUTTON_PATTERN = "lettura carta";
+
 /* To obtain the authentication URL on CIE L3 it is necessary to take the
  * link contained in the "Entra con lettura carta CIE" button.
  * This link can then be used on CieManager.
@@ -21,7 +23,7 @@ const injectedJavaScript = `
     (function() {
       function sendDocumentContent() {
         const idpAuthUrl = [...document.querySelectorAll("a")]
-        .filter(a => a.textContent.includes("lettura carta CIE"))
+        .filter(a => a.textContent.toLowerCase().includes("${AUTH_BUTTON_PATTERN}"))
         .map(a=>a.href)[0];
 
         if(idpAuthUrl) {


### PR DESCRIPTION
#### List of Changes

- Changed the pattern to find the CIE authentication link (`a` element) to "lettura carta"
- Set the `a` text to lower case before matching the pattern

#### Motivation and Context

The CIE + PIN authentication method stopped working after the link text was changed in the CIE web app.

#### How Has This Been Tested?

Tested on `io-app` to get a wallet instance.