### PR TITLE
chore: [SIW-1684] Expose `iat` and `exp` claims

### DIFF
--- a/src/credential/issuance/07-verify-and-parse-credential.ts
+++ b/src/credential/issuance/07-verify-and-parse-credential.ts
@@ -215,7 +215,7 @@ const verifyAndParseCredentialSdJwt: WithFormat<"vc+sd-jwt"> = async (
  * @param credential The encoded credential returned by {@link obtainCredential}
  * @param format The format of the credentual returned by {@link obtainCredential}
  * @param context.credentialCryptoContext The crypto context used to obtain the credential in {@link obtainCredential}
- * @returns A parsed credential with attributes in plain value
+ * @returns A parsed credential with attributes in plain value, the expiration and issuance date of the credential
  * @throws {IoWalletError} If the credential signature is not verified with the Issuer key set
  * @throws {IoWalletError} If the credential is not bound to the provided user key
  * @throws {IoWalletError} If the credential data fail to parse

--- a/src/credential/issuance/README.md
+++ b/src/credential/issuance/README.md
@@ -303,7 +303,7 @@ const { credential, format } = await Credential.Issuance.obtainCredential(
 );
 
 // Parse and verify the eID credential
-const { parsedCredential } = await Credential.Issuance.verifyAndParseCredential(
+const { parsedCredential, issuedAt, expiration } = await Credential.Issuance.verifyAndParseCredential(
   issuerConf,
   credential,
   format,
@@ -315,6 +315,8 @@ return {
   credential,
   keyTag: credentialKeyTag,
   credentialType,
+  issuedAt,
+  expiration
 };
 ```
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- `verifyAndParseCredential` returns `iat` and `exp` claims as `issuedAt` and `expiration` respectively

#### Motivation and Context

We need to know the expiration and issuance date of credentials. The `exp` claim is included in the JWT payload, the `iat` is found among disclosures.

This PR attempts to expose those claims in a simple and backward-compatible way, adding them to the object returned by `verifyAndParseCredential`. Since this function is always called at the end of the issuance flow, it is convenient to also get some additional metadata without requiring another step of verification/decode later.

The use of `includeUndefinedAttributes` was discarded to avoid getting claims not declared in the issuer configuration.

#### Checklist:

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
