### PR TITLE
chore: [SIW-1632] Reuse the Wallet Instance Attestation in the example app

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -73,6 +73,9 @@ PODS:
   - hermes-engine (0.72.14):
     - hermes-engine/Pre-built (= 0.72.14)
   - hermes-engine/Pre-built (0.72.14)
+  - io-react-native-secure-storage (0.1.1):
+    - RCT-Folly (= 2021.07.22.00)
+    - React-Core
   - JOSESwift (2.4.0)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
@@ -566,6 +569,7 @@ DEPENDENCIES:
   - FlipperKit/SKIOSNetworkPlugin (= 0.182.0)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
+  - io-react-native-secure-storage (from `../node_modules/io-react-native-secure-storage`)
   - libevent (~> 2.1.12)
   - OpenSSL-Universal (= 1.1.1100)
   - "pagopa-io-react-native-crypto (from `../node_modules/@pagopa/io-react-native-crypto`)"
@@ -649,6 +653,8 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
+  io-react-native-secure-storage:
+    :path: "../node_modules/io-react-native-secure-storage"
   pagopa-io-react-native-crypto:
     :path: "../node_modules/@pagopa/io-react-native-crypto"
   pagopa-io-react-native-integrity:
@@ -759,6 +765,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: b213bace5f31766ad1434d2d9b2cbf04cf92a2b6
+  io-react-native-secure-storage: 5e6f84d27ead13de84f2014ecc767bffdc3e97e9
   JOSESwift: 7ff178bb9173ff42c6e990929a9f2fa702a34f69
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c

--- a/example/package.json
+++ b/example/package.json
@@ -25,6 +25,7 @@
     "@types/lodash": "^4.17.7",
     "fp-ts": "^2.16.9",
     "i18n-js": "^4.4.3",
+    "io-react-native-secure-storage": "^0.1.1",
     "io-ts": "^2.2.21",
     "lodash": "^4.17.21",
     "react": "18.2.0",

--- a/example/src/store/reducers/attestation.ts
+++ b/example/src/store/reducers/attestation.ts
@@ -1,9 +1,11 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { asyncStatusInitial } from "../utils";
+import { persistReducer, type PersistConfig } from "redux-persist";
 import { getAttestationThunk } from "../../thunks/attestation";
-import type { RootState, AsyncStatus } from "../types";
-import { sessionReset } from "./sesssion";
+import { createSecureStorage } from "../storage";
+import type { AsyncStatus, RootState } from "../types";
+import { asyncStatusInitial } from "../utils";
 import { instanceReset } from "./instance";
+import { sessionReset } from "./sesssion";
 
 // State type definition for the attestion slice
 type AttestationState = {
@@ -21,7 +23,7 @@ const initialState: AttestationState = {
  * Redux slice for the attestion state. It contains the obtained attestation.
  * Currently it is not persisted or reused since each operation requires a new attestation.
  */
-export const attestationSlice = createSlice({
+const attestationSlice = createSlice({
   name: "attestation",
   initialState,
   reducers: {
@@ -64,6 +66,23 @@ export const attestationSlice = createSlice({
  * Exports the actions for the attestaion slice.
  */
 export const { attestationReset } = attestationSlice.actions;
+
+/**
+ * Persist configuration for the attestation slice.
+ */
+const persistConfig: PersistConfig<AttestationState> = {
+  key: "attestation",
+  storage: createSecureStorage(),
+  whitelist: ["attestation"],
+};
+
+/**
+ * Persisted reducer for the credential slice.
+ */
+export const attestationReducer = persistReducer(
+  persistConfig,
+  attestationSlice.reducer
+);
 
 /**
  * Selector which returns the attestation state of the related async operation.

--- a/example/src/store/reducers/attestation.ts
+++ b/example/src/store/reducers/attestation.ts
@@ -1,4 +1,4 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSelector, createSlice } from "@reduxjs/toolkit";
 import { persistReducer, type PersistConfig } from "redux-persist";
 import { getAttestationThunk } from "../../thunks/attestation";
 import { createSecureStorage } from "../storage";
@@ -6,6 +6,7 @@ import type { AsyncStatus, RootState } from "../types";
 import { asyncStatusInitial } from "../utils";
 import { instanceReset } from "./instance";
 import { sessionReset } from "./sesssion";
+import { WalletInstanceAttestation } from "@pagopa/io-react-native-wallet";
 
 // State type definition for the attestion slice
 type AttestationState = {
@@ -99,3 +100,22 @@ export const selectAttestationAsyncStatus = (state: RootState) =>
  */
 export const selectAttestation = (state: RootState) =>
   state.attestation.attestation;
+
+/**
+ * Checks if the Wallet Instance Attestation needs to be requested by
+ * checking the expiry date
+ * @param state - the root state of the Redux store
+ * @returns true if the Wallet Instance Attestation is expired or not present
+ */
+export const shouldRequestAttestationSelector = createSelector(
+  selectAttestation,
+  (attestation) => {
+    if (!attestation) {
+      return true;
+    }
+    const { payload } = WalletInstanceAttestation.decode(attestation);
+    const expiryDate = new Date(payload.exp * 1000);
+    const now = new Date();
+    return now > expiryDate;
+  }
+);

--- a/example/src/store/reducers/credential.ts
+++ b/example/src/store/reducers/credential.ts
@@ -1,6 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { persistReducer, type PersistConfig } from "redux-persist";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import {
   getCredentialStatusAttestationThunk,
   getCredentialThunk,
@@ -14,6 +13,7 @@ import type {
 import { asyncStatusInitial } from "../utils";
 import { sessionReset } from "./sesssion";
 import { instanceReset } from "./instance";
+import { createSecureStorage } from "../storage";
 
 /**
  * State type definition for the credential slice.
@@ -186,7 +186,7 @@ export const { credentialReset } = credentialSlice.actions;
  */
 const persistConfig: PersistConfig<CredentialState> = {
   key: "credential",
-  storage: AsyncStorage,
+  storage: createSecureStorage(),
   whitelist: ["credentials"],
 };
 

--- a/example/src/store/reducers/pid.ts
+++ b/example/src/store/reducers/pid.ts
@@ -1,21 +1,21 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { persistReducer, type PersistConfig } from "redux-persist";
-import AsyncStorage from "@react-native-async-storage/async-storage";
+import { getPidThunk } from "../../thunks/pid";
 import {
   continueCieL3FlowThunk,
   prepareCieL3FlowParamsThunk,
   type PrepareCieL3FlowParamsThunkOutput,
 } from "../../thunks/pidCieL3";
+import { createSecureStorage } from "../storage";
 import type {
-  RootState,
   AsyncStatus,
   PidAuthMethods,
   PidResult,
+  RootState,
 } from "../types";
 import { asyncStatusInitial } from "../utils";
-import { sessionReset } from "./sesssion";
 import { instanceReset } from "./instance";
-import { getPidThunk } from "../../thunks/pid";
+import { sessionReset } from "./sesssion";
 
 /**
  * State type definition for the PID slice.
@@ -196,7 +196,7 @@ export const { pidCiel3FlowReset } = pidSlice.actions;
  */
 const persistConfig: PersistConfig<PidState> = {
   key: "pid",
-  storage: AsyncStorage,
+  storage: createSecureStorage(),
   whitelist: ["pid"],
 };
 

--- a/example/src/store/storage.ts
+++ b/example/src/store/storage.ts
@@ -1,0 +1,18 @@
+import * as SecureStorage from "io-react-native-secure-storage";
+import { type Storage } from "redux-persist";
+
+export const createSecureStorage = (): Storage => {
+  return {
+    getItem: async (key) => {
+      try {
+        return await SecureStorage.get(key);
+      } catch (err) {
+        return undefined;
+      }
+    },
+
+    setItem: (key, value) => SecureStorage.put(key, value),
+
+    removeItem: (key) => SecureStorage.remove(key),
+  };
+};

--- a/example/src/store/store.ts
+++ b/example/src/store/store.ts
@@ -10,7 +10,7 @@ import {
   REHYDRATE,
 } from "redux-persist";
 import { instanceReducer } from "./reducers/instance";
-import { attestationSlice } from "./reducers/attestation";
+import { attestationReducer } from "./reducers/attestation";
 import { credentialReducer } from "./reducers/credential";
 import { debugSlice } from "./reducers/debug";
 import { environmentReducer } from "./reducers/environment";
@@ -25,7 +25,7 @@ export const store = configureStore({
     debug: debugSlice.reducer,
     session: sessionReducer,
     instance: instanceReducer,
-    attestation: attestationSlice.reducer,
+    attestation: attestationReducer,
     credential: credentialReducer,
     pid: pidReducer,
   },

--- a/example/src/thunks/credential.ts
+++ b/example/src/thunks/credential.ts
@@ -2,7 +2,10 @@ import {
   createCryptoContextFor,
   Credential,
 } from "@pagopa/io-react-native-wallet";
-import { selectAttestation } from "../store/reducers/attestation";
+import {
+  selectAttestation,
+  shouldRequestAttestationSelector,
+} from "../store/reducers/attestation";
 import { selectEnv } from "../store/reducers/environment";
 import { selectPid } from "../store/reducers/pid";
 import type {
@@ -16,6 +19,7 @@ import {
 import { WIA_KEYTAG } from "../utils/crypto";
 import { getEnv } from "../utils/environment";
 import { createAppAsyncThunk } from "./utils";
+import { getAttestationThunk } from "./attestation";
 
 /**
  * Type definition for the input of the {@link getCredentialThunk}.
@@ -52,7 +56,13 @@ type GetCredentialStatusAttestationThunkOutput = {
 export const getCredentialThunk = createAppAsyncThunk<
   CredentialResult,
   GetCredentialThunkInput
->("credential/credentialGet", async (args, { getState }) => {
+>("credential/credentialGet", async (args, { getState, dispatch }) => {
+  // Checks if the wallet instance attestation needs to be reuqested
+  if (shouldRequestAttestationSelector(getState())) {
+    await dispatch(getAttestationThunk());
+  }
+
+  // Gets the Wallet Instance Attestation from the persisted store
   const walletInstanceAttestation = selectAttestation(getState());
   if (!walletInstanceAttestation) {
     throw new Error("Wallet Instance Attestation not found");

--- a/example/src/thunks/credential.ts
+++ b/example/src/thunks/credential.ts
@@ -1,13 +1,10 @@
 import {
-  Credential,
-  WalletInstanceAttestation,
   createCryptoContextFor,
+  Credential,
 } from "@pagopa/io-react-native-wallet";
-import appFetch from "../utils/fetch";
-import { regenerateCryptoKey, WIA_KEYTAG } from "../utils/crypto";
-import { createAppAsyncThunk } from "./utils";
-import { selectInstanceKeyTag } from "../store/reducers/instance";
-import { getIntegrityContext } from "../utils/integrity";
+import { selectAttestation } from "../store/reducers/attestation";
+import { selectEnv } from "../store/reducers/environment";
+import { selectPid } from "../store/reducers/pid";
 import type {
   CredentialResult,
   SupportedCredentialsWithoutPid,
@@ -16,9 +13,9 @@ import {
   getCredential,
   getCredentialStatusAttestation,
 } from "../utils/credential";
-import { selectEnv } from "../store/reducers/environment";
+import { WIA_KEYTAG } from "../utils/crypto";
 import { getEnv } from "../utils/environment";
-import { selectPid } from "../store/reducers/pid";
+import { createAppAsyncThunk } from "./utils";
 
 /**
  * Type definition for the input of the {@link getCredentialThunk}.
@@ -56,36 +53,16 @@ export const getCredentialThunk = createAppAsyncThunk<
   CredentialResult,
   GetCredentialThunkInput
 >("credential/credentialGet", async (args, { getState }) => {
-  // Retrieve the integrity key tag from the store and create its context
-  const integrityKeyTag = selectInstanceKeyTag(getState());
-  if (!integrityKeyTag) {
-    throw new Error("Integrity key not found");
+  const walletInstanceAttestation = selectAttestation(getState());
+  if (!walletInstanceAttestation) {
+    throw new Error("Wallet Instance Attestation not found");
   }
-  const integrityContext = getIntegrityContext(integrityKeyTag);
 
-  // generate Key for Wallet Instance Attestation
-  // ensure the key esists befor starting the issuing process
-  await regenerateCryptoKey(WIA_KEYTAG);
   const wiaCryptoContext = createCryptoContextFor(WIA_KEYTAG);
 
   // Get env URLs
   const env = selectEnv(getState());
-  const {
-    WALLET_PROVIDER_BASE_URL,
-    WALLET_EAA_PROVIDER_BASE_URL,
-    REDIRECT_URI,
-  } = getEnv(env);
-  /**
-   * Obtains a new Wallet Instance Attestation.
-   * WARNING: The integrity context must be the same used when creating the Wallet Instance with the same keytag.
-   */
-  const walletInstanceAttestation =
-    await WalletInstanceAttestation.getAttestation({
-      wiaCryptoContext,
-      integrityContext,
-      walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
-      appFetch,
-    });
+  const { WALLET_EAA_PROVIDER_BASE_URL, REDIRECT_URI } = getEnv(env);
 
   const { credentialType } = args;
 

--- a/example/src/thunks/pid.ts
+++ b/example/src/thunks/pid.ts
@@ -1,21 +1,16 @@
-import {
-  WalletInstanceAttestation,
-  createCryptoContextFor,
-} from "@pagopa/io-react-native-wallet";
-import appFetch from "../utils/fetch";
-import { regenerateCryptoKey, WIA_KEYTAG } from "../utils/crypto";
-import { createAppAsyncThunk } from "./utils";
-import { selectInstanceKeyTag } from "../store/reducers/instance";
-import { getIntegrityContext } from "../utils/integrity";
+import { createCryptoContextFor } from "@pagopa/io-react-native-wallet";
+import { selectAttestation } from "../store/reducers/attestation";
 import { credentialReset } from "../store/reducers/credential";
+import { selectEnv } from "../store/reducers/environment";
 import type {
   PidAuthMethods,
   PidResult,
   SupportedCredentials,
 } from "../store/types";
 import { getPid } from "../utils/credential";
-import { selectEnv } from "../store/reducers/environment";
+import { WIA_KEYTAG } from "../utils/crypto";
 import { getEnv } from "../utils/environment";
+import { createAppAsyncThunk } from "./utils";
 
 /**
  * Type definition for the input of the {@link getCredentialThunk}.
@@ -35,36 +30,16 @@ type GetPidThunkInput = {
 export const getPidThunk = createAppAsyncThunk<PidResult, GetPidThunkInput>(
   "pid/pidGet",
   async (args, { getState, dispatch }) => {
-    // Retrieve the integrity key tag from the store and create its context
-    const integrityKeyTag = selectInstanceKeyTag(getState());
-    if (!integrityKeyTag) {
-      throw new Error("Integrity key not found");
+    const walletInstanceAttestation = selectAttestation(getState());
+    if (!walletInstanceAttestation) {
+      throw new Error("Wallet Instance Attestation not found");
     }
-    const integrityContext = getIntegrityContext(integrityKeyTag);
 
-    // generate Key for Wallet Instance Attestation
-    // ensure the key esists befor starting the issuing process
-    await regenerateCryptoKey(WIA_KEYTAG);
     const wiaCryptoContext = createCryptoContextFor(WIA_KEYTAG);
 
     // Get env URLs
     const env = selectEnv(getState());
-    const {
-      WALLET_PROVIDER_BASE_URL,
-      WALLET_PID_PROVIDER_BASE_URL,
-      REDIRECT_URI,
-    } = getEnv(env);
-    /**
-     * Obtains a new Wallet Instance Attestation.
-     * WARNING: The integrity context must be the same used when creating the Wallet Instance with the same keytag.
-     */
-    const walletInstanceAttestation =
-      await WalletInstanceAttestation.getAttestation({
-        wiaCryptoContext,
-        integrityContext,
-        walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
-        appFetch,
-      });
+    const { WALLET_PID_PROVIDER_BASE_URL, REDIRECT_URI } = getEnv(env);
 
     const { idpHint, credentialType } = args;
     // Resets the credential state before obtaining a new PID

--- a/example/src/thunks/pid.ts
+++ b/example/src/thunks/pid.ts
@@ -1,5 +1,8 @@
 import { createCryptoContextFor } from "@pagopa/io-react-native-wallet";
-import { selectAttestation } from "../store/reducers/attestation";
+import {
+  selectAttestation,
+  shouldRequestAttestationSelector,
+} from "../store/reducers/attestation";
 import { credentialReset } from "../store/reducers/credential";
 import { selectEnv } from "../store/reducers/environment";
 import type {
@@ -11,6 +14,7 @@ import { getPid } from "../utils/credential";
 import { WIA_KEYTAG } from "../utils/crypto";
 import { getEnv } from "../utils/environment";
 import { createAppAsyncThunk } from "./utils";
+import { getAttestationThunk } from "./attestation";
 
 /**
  * Type definition for the input of the {@link getCredentialThunk}.
@@ -30,6 +34,12 @@ type GetPidThunkInput = {
 export const getPidThunk = createAppAsyncThunk<PidResult, GetPidThunkInput>(
   "pid/pidGet",
   async (args, { getState, dispatch }) => {
+    // Checks if the wallet instance attestation needs to be reuqested
+    if (shouldRequestAttestationSelector(getState())) {
+      await dispatch(getAttestationThunk());
+    }
+
+    // Gets the Wallet Instance Attestation from the persisted store
     const walletInstanceAttestation = selectAttestation(getState());
     if (!walletInstanceAttestation) {
       throw new Error("Wallet Instance Attestation not found");

--- a/example/src/thunks/pidCieL3.ts
+++ b/example/src/thunks/pidCieL3.ts
@@ -1,21 +1,20 @@
+import { generate } from "@pagopa/io-react-native-crypto";
 import {
   createCryptoContextFor,
   Credential,
   WalletInstanceAttestation,
 } from "@pagopa/io-react-native-wallet";
-import { selectInstanceKeyTag } from "../store/reducers/instance";
-import { DPOP_KEYTAG, regenerateCryptoKey, WIA_KEYTAG } from "../utils/crypto";
-import { getIntegrityContext } from "../utils/integrity";
-import { createAppAsyncThunk } from "./utils";
-import appFetch from "../utils/fetch";
-import uuid from "react-native-uuid";
-import { generate } from "@pagopa/io-react-native-crypto";
-import { credentialReset } from "../store/reducers/credential";
 import parseUrl from "parse-url";
-import type { PidResult } from "../store/types";
+import uuid from "react-native-uuid";
+import { selectAttestation } from "../store/reducers/attestation";
+import { credentialReset } from "../store/reducers/credential";
 import { selectEnv } from "../store/reducers/environment";
-import { getEnv } from "../utils/environment";
 import { selectPidCieL3FlowParams } from "../store/reducers/pid";
+import type { PidResult } from "../store/types";
+import { DPOP_KEYTAG, regenerateCryptoKey, WIA_KEYTAG } from "../utils/crypto";
+import { getEnv } from "../utils/environment";
+import appFetch from "../utils/fetch";
+import { createAppAsyncThunk } from "./utils";
 
 // This can be any URL, as long as it has http or https as its protocol, otherwise it cannot be managed by the webview.
 // PUT ME IN UTILS OR ENV
@@ -71,32 +70,20 @@ export const prepareCieL3FlowParamsThunk = createAppAsyncThunk<
   PrepareCieL3FlowParamsThunkOutput,
   PrepareCieL3FlowParamsThunkInput
 >("ciel3/flowParamsPrepare", async (args, { getState, dispatch }) => {
+  const walletInstanceAttestation = selectAttestation(getState());
+  if (!walletInstanceAttestation) {
+    throw new Error("Wallet Instance Attestation not found");
+  }
+
   // Reset the credential state before obtaining a new PID
   dispatch(credentialReset());
   const { idpHint, ciePin } = args;
-  // Retrieve the integrity key tag from the store and create its context
-  const integrityKeyTag = selectInstanceKeyTag(getState());
-  if (!integrityKeyTag) {
-    throw new Error("Integrity key not found");
-  }
-  const integrityContext = getIntegrityContext(integrityKeyTag);
 
-  // Obtain a wallet attestation. A wallet instance must be created before this step.
-  await regenerateCryptoKey(WIA_KEYTAG);
   const wiaCryptoContext = createCryptoContextFor(WIA_KEYTAG);
 
   // Get env
   const env = selectEnv(getState());
-  const { WALLET_PROVIDER_BASE_URL, WALLET_PID_PROVIDER_BASE_URL } =
-    getEnv(env);
-
-  const walletInstanceAttestation =
-    await WalletInstanceAttestation.getAttestation({
-      wiaCryptoContext,
-      integrityContext,
-      walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
-      appFetch,
-    });
+  const { WALLET_PID_PROVIDER_BASE_URL } = getEnv(env);
 
   // Start the issuance flow
   const startFlow: Credential.Issuance.StartFlow = () => ({

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3909,6 +3909,11 @@ invariant@2.2.4, invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
+io-react-native-secure-storage@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/io-react-native-secure-storage/-/io-react-native-secure-storage-0.1.1.tgz#c1fb28125f6c9f8f1b7436198fab726f4ae790ef"
+  integrity sha512-ceBQImvJoxGoyD5tDZ9E0SqDb/9CKPSR5XrMfDDBJ5topKDXCUkC9tiuEv/RYhOOzLbaLR7qvvkEtla5fcnHmg==
+
 io-ts@^2.2.21:
   version "2.2.21"
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.21.tgz#4ef754176f7082a1099d04c7d5c4ea53267c530a"


### PR DESCRIPTION
#### List of Changes

This PR removes the need to get a new Wallet Instance Attestation every time there is a credential issuance.
Once the WIA is obtained, it is stored and persisted to the device via Secure Storage and then used for the credential issuance.  The WIA is obtained again only when it expires.
This PR also introduces Secure Storage for WIA, PID and Credentials persistance.

#### Motivation and Context

Since new WIA requests on Android requires a Play Integrity API call, this change is required to reduce the Play Integrity API usage.

#### How Has This Been Tested?

Run the example app and check that the WIA is requested only once or when it is expired

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
