### PR TITLE
chore: [SIW-1707] Handle undefined `iat`claim

### DIFF
--- a/src/credential/issuance/07-verify-and-parse-credential.ts
+++ b/src/credential/issuance/07-verify-and-parse-credential.ts
@@ -26,7 +26,7 @@ export type VerifyAndParseCredential = (
 ) => Promise<{
   parsedCredential: ParsedCredential;
   expiration: Date;
-  issuedAt?: Date;
+  issuedAt: Date | undefined;
 }>;
 
 // The credential as a collection of attributes in plain value

--- a/src/credential/issuance/07-verify-and-parse-credential.ts
+++ b/src/credential/issuance/07-verify-and-parse-credential.ts
@@ -26,7 +26,7 @@ export type VerifyAndParseCredential = (
 ) => Promise<{
   parsedCredential: ParsedCredential;
   expiration: Date;
-  issuedAt: Date;
+  issuedAt?: Date;
 }>;
 
 // The credential as a collection of attributes in plain value
@@ -211,12 +211,15 @@ const verifyAndParseCredentialSdJwt: WithFormat<"vc+sd-jwt"> = async (
     includeUndefinedAttributes
   );
 
+  const maybeIssuedAt = getValueFromDisclosures(decoded.disclosures, "iat");
+
   return {
     parsedCredential,
     expiration: new Date(decoded.sdJwt.payload.exp * 1000),
-    issuedAt: new Date(
-      getValueFromDisclosures(decoded.disclosures, "iat") * 1000
-    ),
+    issuedAt:
+      typeof maybeIssuedAt === "number"
+        ? new Date(maybeIssuedAt * 1000)
+        : undefined,
   };
 };
 


### PR DESCRIPTION
#### List of Changes

- `verifyAndParseCredential` can return an undefined `issuedAt`

#### Motivation and Context

Although SD-JWTs should always contain the `iat` claim, we cannot have the absolute certainty. This PR takes a safe approach and handles a missing `iat` claim among disclosures.

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
