### PR TITLE
feat: [SIW-1591] Add 409 handling with custom exception for wallet provider

### DIFF
--- a/openapi/wallet-provider.yaml
+++ b/openapi/wallet-provider.yaml
@@ -1,7 +1,11 @@
 openapi: 3.0.3
 info:
-  title: IO Wallet - User API
+  title: IO Wallet
   version: 1.0.0
+servers:
+  - url: https://api-app.io.pagopa.it/api/v1/wallet
+security:
+  - Bearer: []
 paths:
   /nonce:
     get:
@@ -30,6 +34,12 @@ paths:
       responses:
         "204":
           description: Wallet instance successfully created
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "422":
           $ref: "#/components/responses/UnprocessableContent"
         "500":
@@ -53,18 +63,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WalletAttestationView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "403":
-          description: The wallet instance was revoked
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: The wallet instance was not found
-          $ref: "#/components/responses/NotFound"
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "422":
           $ref: "#/components/responses/UnprocessableContent"
         "500":
           $ref: "#/components/responses/Unexpected"
 
 components:
+  securitySchemes:
+    Bearer:
+      type: apiKey
+      name: Authorization
+      in: header
+
   responses:
     Forbidden:
       description: The server understands the request but refuses to authorize it
@@ -82,6 +100,20 @@ components:
 
     UnprocessableContent:
       description: Unprocessable Content
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+
+    BadRequest:
+      description: Validation error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+
+    Conflict:
+      description: There has been a conflict
       content:
         application/json:
           schema:
@@ -187,15 +219,3 @@ components:
             An absolute URI that identifies the specific occurrence of the
             problem. It may or may not yield further information if
             dereferenced.
-
-    FiscalCode:
-      type: string
-      description: User's fiscal code.
-      format: FiscalCode
-      x-import: "@pagopa/ts-commons/lib/strings"
-      example: SPNDNL80R13C555X
-
-    Id:
-      type: string
-      description: UUID
-      example: 32928ece-6ca0-488c-9a6a-eb8ee66ab69a

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -335,6 +335,75 @@ export class WalletInstanceNotFoundError extends IoWalletError {
 }
 
 /**
+ * An error subclass thrown when obtaining a wallet instance attestation which fails due to the integrity.
+ */
+export class WalletInstanceIntegrityFailedError extends IoWalletError {
+  static get code(): "ERR_IO_WALLET_INSTANCE_INTEGRITY_FAILED" {
+    return "ERR_IO_WALLET_INSTANCE_INTEGRITY_FAILED";
+  }
+
+  code = "ERR_IO_WALLET_INSTANCE_INTEGRITY_FAILED";
+
+  reason: string;
+
+  claim: string;
+
+  constructor(message: string, claim: string, reason: string = "unspecified") {
+    super(serializeAttrs({ message, claim, reason }));
+    this.reason = reason;
+    this.claim = claim;
+  }
+}
+
+/**
+ * An error subclass thrown when an error occurs during the wallet instance creation process.
+ */
+export class WalletInstanceCreationError extends IoWalletError {
+  static get code(): "ERR_IO_WALLET_INSTANCE_CREATION_ERROR" {
+    return "ERR_IO_WALLET_INSTANCE_CREATION_ERROR";
+  }
+
+  code = "ERR_IO_WALLET_INSTANCE_CREATION_ERROR";
+
+  /** The Claim for which the validation failed. */
+  claim: string;
+
+  /** Reason code for the validation failure. */
+  reason: string;
+
+  constructor(
+    message: string,
+    claim: string = "unspecified",
+    reason: string = "unspecified"
+  ) {
+    super(serializeAttrs({ message, claim, reason }));
+    this.claim = claim;
+    this.reason = reason;
+  }
+}
+
+/**
+ * An error subclass thrown when obtaining a wallet instance attestation which fails due to the integrity.
+ */
+export class WalletInstanceCreationIntegrityError extends IoWalletError {
+  static get code(): "ERR_IO_WALLET_INSTANCE_CREATION_INTEGRITY_ERROR" {
+    return "ERR_IO_WALLET_INSTANCE_CREATION_INTEGRITY_ERROR";
+  }
+
+  code = "ERR_IO_WALLET_INSTANCE_CREATION_INTEGRITY_ERROR";
+
+  reason: string;
+
+  claim: string;
+
+  constructor(message: string, claim: string, reason: string = "unspecified") {
+    super(serializeAttrs({ message, claim, reason }));
+    this.reason = reason;
+    this.claim = claim;
+  }
+}
+
+/**
  * An error subclass thrown when an error occurs during the authorization process.
  */
 export class AuthorizationError extends IoWalletError {

--- a/src/wallet-instance-attestation/README.md
+++ b/src/wallet-instance-attestation/README.md
@@ -33,3 +33,9 @@ return issuedAttestation;
 ```
 
 The returned `issuedAttestation` is supposed to be stored and used for any future operation that requires a Wallet Instance Attestation. The wallet attestation has a limited validity and must be regenerated when it expires.
+
+## Mapped results
+
+### 409 Conflict (WalletInstanceIntegrityFailedError)
+
+A `409 Conflict` response is returned by the wallet provider when an integrity check fails.

--- a/src/wallet-instance-attestation/issuing.ts
+++ b/src/wallet-instance-attestation/issuing.ts
@@ -8,6 +8,7 @@ import {
   WalletInstanceRevokedError,
   WalletInstanceNotFoundError,
   WalletInstanceAttestationIssuingError,
+  WalletInstanceIntegrityFailedError,
 } from "../utils/errors";
 import { TokenResponse } from "./types";
 
@@ -130,6 +131,14 @@ const handleAttestationCreationError = (e: unknown) => {
   if (e.statusCode === 404) {
     throw new WalletInstanceNotFoundError(
       "Unable to get an attestation for a Wallet Instance that does not exist",
+      e.claim,
+      e.reason
+    );
+  }
+
+  if (e.statusCode === 409) {
+    throw new WalletInstanceIntegrityFailedError(
+      "Unable to get an attestation for a Wallet Instance that failed the integrity check",
       e.claim,
       e.reason
     );

--- a/src/wallet-instance/README.md
+++ b/src/wallet-instance/README.md
@@ -27,3 +27,9 @@ return integrityKeyTag;
 ```
 
 The returned `integrityKeyTag` is supposed to be stored and used to verify the integrity of the device in the future when using an `IntegrityContext` object. It must be regenerated if another wallet instance is created.
+
+## Mapped results
+
+### 409 Conflict (WalletInstanceCreationIntegrityError)
+
+A `409 Conflict` response is returned by the wallet provider when an integrity check fails.

--- a/src/wallet-instance/index.ts
+++ b/src/wallet-instance/index.ts
@@ -1,5 +1,10 @@
 import { getWalletProviderClient } from "../client";
 import type { IntegrityContext } from "..";
+import {
+  WalletInstanceCreationError,
+  WalletInstanceCreationIntegrityError,
+  WalletProviderResponseError,
+} from "../utils/errors";
 
 export async function createWalletInstance(context: {
   integrityContext: IntegrityContext;
@@ -17,13 +22,35 @@ export async function createWalletInstance(context: {
   const hardwareKeyTag = integrityContext.getHardwareKeyTag();
 
   //2. Create Wallet Instance
-  await api.post("/wallet-instances", {
-    body: {
-      challenge,
-      key_attestation: keyAttestation,
-      hardware_key_tag: hardwareKeyTag,
-    },
-  });
+  await api
+    .post("/wallet-instances", {
+      body: {
+        challenge,
+        key_attestation: keyAttestation,
+        hardware_key_tag: hardwareKeyTag,
+      },
+    })
+    .catch(handleCreateWalletInstanceError);
 
   return hardwareKeyTag;
 }
+
+const handleCreateWalletInstanceError = (e: unknown) => {
+  if (!(e instanceof WalletProviderResponseError)) {
+    throw e;
+  }
+
+  if (e.statusCode === 409) {
+    throw new WalletInstanceCreationIntegrityError(
+      "Unable to get an attestation for a Wallet Instance that failed the integrity check",
+      e.claim,
+      e.reason
+    );
+  }
+
+  throw new WalletInstanceCreationError(
+    `Unable to obtain wallet instance attestation [response status code: ${e.statusCode}]`,
+    e.claim,
+    e.reason
+  );
+};


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Update the `wallet-provider.yaml` specs due to changes in how the errors are mapped for certain endpoints like `/token` and `/wallet-instance`; 
- Create custom exceptions which are thrown when an error related to the integrity checks for `/token` and `/wallet-instances` fails, returning a `409` HTTP code; 
- Map these errors in their relative flows step for registering a wallet instance and obtaining an attestation.
<!--- Describe your changes in detail -->

#### Motivation and Context
This changes allows the consumer app to receive a custom error when an integrity check fails, thus allowing a specific text copy to be shown to the user.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
- Open the example app and login; 
- Start a proxy like `Proxyman`;
- Try to register a wallet instance and obtain an attestation, everything should work just as before;
- Manually map the result of `/token` and `/wallet-instances` to `409 Conflict`;
- Try again to register a wallet instance and obtain an attestation. An error should occur. Check in the debug menu that the error is the one supposed to be thrown in this specific case.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
