### PR TITLE
chore: [SIW-1779] Handle error codes during credential issuance and status attestation

### DIFF
--- a/src/credential/issuance/06-obtain-credential.ts
+++ b/src/credential/issuance/06-obtain-credential.ts
@@ -157,8 +157,8 @@ export const obtainCredential: ObtainCredential = async (
  * Handle the credential error by mapping it to a custom exception.
  * If the error is not an instance of {@link UnexpectedStatusCodeError}, it is thrown as is.
  * @param e - The error to be handled
- * @throws {@link StatusAttestationError} if the status code is different from 404
- * @throws {@link StatusAttestationInvalid} if the status code is 404 (meaning the credential is invalid)
+ * @throws {@link CredentialRequestError} if the status code is different from 404
+ * @throws {@link CredentialInvalidStatusError} if the status code is 404 (meaning the credential is invalid)
  */
 const handleObtainCredentialError = (e: unknown) => {
   if (!(e instanceof UnexpectedStatusCodeError)) {

--- a/src/credential/issuance/README.md
+++ b/src/credential/issuance/README.md
@@ -43,14 +43,16 @@ graph TD;
 
 A `201 Created` response is returned by the credential issuer when the request has been queued because the credential cannot be issued synchronously. The consumer should try to obtain the credential at a later time.
 
-### 404 Not Found (CredentialNotEntitledError)
-
-A `404 Not Found` response is returned by the credential issuer when the authenticated user is not entitled to receive the requested credential.
-
-### 201 Created (CredentialIssuingNotSynchronousError)
-
 Although `201 Created` is not considered an error, it is mapped as an error in this context in order to handle the case where the credential issuance is not synchronous.
 This allows keeping the flow consistent and handle the case where the credential is not immediately available.
+
+### 403 Forbidden (CredentialInvalidStatusError)
+
+A `403 Forbidden` response is returned by the credential issuer when the requested credential has an invalid status. It might contain more details in the `errorCode` property.
+
+### 404 Not Found (CredentialInvalidStatusError)
+
+A `404 Not Found` response is returned by the credential issuer when the authenticated user is not entitled to receive the requested credential. It might contain more details in the `errorCode` property.
 
 ## Strong authentication for eID issuance (Query Mode)
 

--- a/src/credential/issuance/types.ts
+++ b/src/credential/issuance/types.ts
@@ -30,3 +30,11 @@ export const ResponseUriResultShape = z.object({
 });
 
 export type ResponseMode = "query" | "form_post.jwt";
+
+export const CredentialIssuanceFailureResponse = z.object({
+  error: z.string(),
+});
+
+export type CredentialIssuanceFailureResponse = z.infer<
+  typeof CredentialIssuanceFailureResponse
+>;

--- a/src/credential/status/02-status-attestation.ts
+++ b/src/credential/status/02-status-attestation.ts
@@ -33,7 +33,7 @@ export type StatusAttestation = (
  * @param credential - The credential to be verified
  * @param credentialCryptoContext - The credential's crypto context
  * @param context.appFetch (optional) fetch api implementation. Default: built-in fetch
- * @throws {@link StatusAttestationInvalid} if the status attestation is invalid and thus the credential is not valid
+ * @throws {@link CredentialInvalidStatusError} if the status attestation is invalid and thus the credential is not valid
  * @throws {@link StatusAttestationError} if an error occurs during the status attestation
  * @returns The credential status attestation
  */
@@ -87,7 +87,7 @@ export const statusAttestation: StatusAttestation = async (
  * If the error is not an instance of {@link UnexpectedStatusCodeError}, it is thrown as is.
  * @param e - The error to be handled
  * @throws {@link StatusAttestationError} if the status code is different from 404
- * @throws {@link StatusAttestationInvalid} if the status code is 404 (meaning the credential is invalid)
+ * @throws {@link CredentialInvalidStatusError} if the status code is 404 (meaning the credential is invalid)
  */
 const handleStatusAttestationError = (e: unknown) => {
   if (!(e instanceof UnexpectedStatusCodeError)) {

--- a/src/credential/status/02-status-attestation.ts
+++ b/src/credential/status/02-status-attestation.ts
@@ -13,7 +13,7 @@ import {
 } from "./types";
 import {
   StatusAttestationError,
-  StatusAttestationInvalid,
+  CredentialInvalidStatusError,
   UnexpectedStatusCodeError,
 } from "../../utils/errors";
 
@@ -98,7 +98,7 @@ const handleStatusAttestationError = (e: unknown) => {
     const maybeError = InvalidStatusAttestationResponse.safeParse(
       safeJsonParse(e.responseBody)
     );
-    throw new StatusAttestationInvalid(
+    throw new CredentialInvalidStatusError(
       "Invalid status found for the given credential",
       maybeError.success ? maybeError.data.error : "unknown",
       e.message

--- a/src/credential/status/02-status-attestation.ts
+++ b/src/credential/status/02-status-attestation.ts
@@ -1,12 +1,16 @@
 import {
   getCredentialHashWithouDiscloures,
   hasStatus,
+  safeJsonParse,
   type Out,
 } from "../../utils/misc";
 import type { EvaluateIssuerTrust, ObtainCredential } from "../issuance";
 import { SignJWT, type CryptoContext } from "@pagopa/io-react-native-jwt";
 import uuid from "react-native-uuid";
-import { StatusAttestationResponse } from "./types";
+import {
+  InvalidStatusAttestationResponse,
+  StatusAttestationResponse,
+} from "./types";
 import {
   StatusAttestationError,
   StatusAttestationInvalid,
@@ -91,8 +95,12 @@ const handleStatusAttestationError = (e: unknown) => {
   }
 
   if (e.statusCode === 404) {
+    const maybeError = InvalidStatusAttestationResponse.safeParse(
+      safeJsonParse(e.responseBody)
+    );
     throw new StatusAttestationInvalid(
       "Invalid status found for the given credential",
+      maybeError.success ? maybeError.data.error : "unknown",
       e.message
     );
   }

--- a/src/credential/status/README.md
+++ b/src/credential/status/README.md
@@ -18,7 +18,7 @@ graph TD;
 
 ## Mapped results
 
-### 404 Not Found (StatusAttestationInvalid)
+### 404 Not Found (CredentialInvalidStatusError)
 
 A `404 Not Found` response is returned by the credential issuer when the status attestation is invalid.
 

--- a/src/credential/status/types.ts
+++ b/src/credential/status/types.ts
@@ -41,3 +41,18 @@ export const ParsedStatusAttestation = z.object({
     iat: UnixTime,
   }),
 });
+
+/**
+ * Shape from parsing a status attestation response in case of error.
+ */
+export const InvalidStatusAttestationResponse = z.object({
+  error: z.string(),
+});
+
+/**
+ * Type from parsing a status attestation response in case of error.
+ * Inferred from {@link InvalidStatusAttestationResponse}.
+ */
+export type InvalidStatusAttestationResponse = z.infer<
+  typeof InvalidStatusAttestationResponse
+>;

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -51,7 +51,7 @@ describe("extractErrorMessageFromIssuerConf", () => {
     ).toBeUndefined();
   });
 
-  it("should return the error message with the specified locale", async () => {
+  it("should return the error message grouped by locales", async () => {
     expect(
       extractErrorMessageFromIssuerConf("credential_revoked", {
         credentialType: "MDL",

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -1,0 +1,63 @@
+import type { CredentialIssuerEntityConfiguration } from "../../trust";
+import { extractErrorMessageFromIssuerConf } from "../errors";
+
+type EntityConfig = CredentialIssuerEntityConfiguration["payload"]["metadata"];
+
+describe("extractErrorMessageFromIssuerConf", () => {
+  it("should throw when no credential configuration is found", async () => {
+    expect(() =>
+      extractErrorMessageFromIssuerConf("credential_revoked", {
+        credentialType: "MDL",
+        issuerConf: {
+          openid_credential_issuer: {
+            credential_configurations_supported: {},
+          },
+        } as EntityConfig,
+      })
+    ).toThrow();
+  });
+
+  it("should return undefined when no credential issuance error is found", async () => {
+    expect(
+      extractErrorMessageFromIssuerConf("credential_revoked", {
+        credentialType: "MDL",
+        // @ts-expect-error partial type
+        issuerConf: {
+          openid_credential_issuer: {
+            credential_configurations_supported: {
+              MDL: {},
+            },
+          },
+        } as EntityConfig,
+      })
+    ).toBeUndefined();
+  });
+
+  it("should return the error message with the specified locale", async () => {
+    expect(
+      extractErrorMessageFromIssuerConf("credential_revoked", {
+        credentialType: "MDL",
+        // @ts-expect-error partial type
+        issuerConf: {
+          openid_credential_issuer: {
+            credential_configurations_supported: {
+              MDL: {
+                issuance_errors_supported: {
+                  credential_revoked: {
+                    display: [
+                      { title: "Ciao", description: "Ciao", locale: "it-IT" },
+                      { title: "Hello", description: "Hello", locale: "en-US" },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        } as EntityConfig,
+      })
+    ).toEqual({
+      "it-IT": { title: "Ciao", description: "Ciao" },
+      "en-US": { title: "Hello", description: "Hello" },
+    });
+  });
+});

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -31,6 +31,24 @@ describe("extractErrorMessageFromIssuerConf", () => {
         } as EntityConfig,
       })
     ).toBeUndefined();
+
+    expect(
+      extractErrorMessageFromIssuerConf("credential_revoked", {
+        credentialType: "MDL",
+        // @ts-expect-error partial type
+        issuerConf: {
+          openid_credential_issuer: {
+            credential_configurations_supported: {
+              MDL: {
+                issuance_errors_supported: {
+                  credential_voided: {},
+                },
+              },
+            },
+          },
+        } as EntityConfig,
+      })
+    ).toBeUndefined();
   });
 
   it("should return the error message with the specified locale", async () => {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -464,14 +464,14 @@ export class OperationAbortedError extends IoWalletError {
 }
 
 /**
- * Error subclass thrown when the status attestation for a credential is invalid.
+ * Error subclass thrown when a credential status is invalid, either during issuance or when requesting a status attestation.
  */
-export class StatusAttestationInvalid extends IoWalletError {
-  static get code(): "ERR_STATUS_ATTESTATION_INVALID" {
-    return "ERR_STATUS_ATTESTATION_INVALID";
+export class CredentialInvalidStatusError extends IoWalletError {
+  static get code(): "ERR_CREDENTIAL_INVALID_STATUS" {
+    return "ERR_CREDENTIAL_INVALID_STATUS";
   }
 
-  code = "ERR_STATUS_ATTESTATION_INVALID";
+  code = "ERR_CREDENTIAL_INVALID_STATUS";
 
   /**
    * The error code that should be mapped with one of the `issuance_errors_supported` in the EC.
@@ -499,24 +499,6 @@ export class StatusAttestationError extends IoWalletError {
   }
 
   code = "ERR_STATUS_ATTESTATION_ERROR";
-
-  reason: string;
-
-  constructor(message: string, reason: string = "unspecified") {
-    super(serializeAttrs({ message, reason }));
-    this.reason = reason;
-  }
-}
-
-/**
- * Error subclass thrown when the the user is not entitled to receive the requested credential.
- */
-export class CredentialNotEntitledError extends IoWalletError {
-  static get code(): "CREDENTIAL_NOT_ENTITLED_ERROR" {
-    return "CREDENTIAL_NOT_ENTITLED_ERROR";
-  }
-
-  code = "CREDENTIAL_NOT_ENTITLED_ERROR";
 
   reason: string;
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -56,8 +56,10 @@ export class UnexpectedStatusCodeError extends IoWalletError {
 
   /** HTTP status code */
   statusCode: number;
+  /** The stringified response body, useful to process the error response */
+  responseBody: string;
 
-  constructor(message: string, statusCode: number) {
+  constructor(message: string, statusCode: number, responseBody: string) {
     super(
       serializeAttrs({
         message,
@@ -65,6 +67,7 @@ export class UnexpectedStatusCodeError extends IoWalletError {
       })
     );
     this.statusCode = statusCode;
+    this.responseBody = responseBody;
   }
 }
 /**
@@ -470,10 +473,19 @@ export class StatusAttestationInvalid extends IoWalletError {
 
   code = "ERR_STATUS_ATTESTATION_INVALID";
 
+  /**
+   * The error code that should be mapped with one of the `issuance_errors_supported` in the EC.
+   */
+  errorCode: string;
   reason: string;
 
-  constructor(message: string, reason: string = "unspecified") {
-    super(serializeAttrs({ message, reason }));
+  constructor(
+    message: string,
+    errorCode: string,
+    reason: string = "unspecified"
+  ) {
+    super(serializeAttrs({ message, errorCode, reason }));
+    this.errorCode = errorCode;
     this.reason = reason;
   }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -588,7 +588,7 @@ export function extractErrorMessageFromIssuerConf(
     return undefined;
   }
 
-  const localesList = issuance_errors_supported[errorCode].display;
+  const localesList = issuance_errors_supported[errorCode]!.display;
 
   return localesList.reduce(
     (acc, { locale, ...rest }) => ({ ...acc, [locale]: rest }),

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -11,11 +11,11 @@ export const hasStatus =
   (status: number) =>
   async (res: Response): Promise<Response> => {
     if (res.status !== status) {
+      const responseBody = await res.text();
       throw new UnexpectedStatusCodeError(
-        `Http request failed. Expected ${status}, got ${res.status}, url: ${
-          res.url
-        } with response: ${await res.text()}`,
-        res.status
+        `Http request failed. Expected ${status}, got ${res.status}, url: ${res.url} with response: ${responseBody}`,
+        res.status,
+        responseBody
       );
     }
     return res;
@@ -109,3 +109,11 @@ export const createAbortPromiseFromSignal = (signal: AbortSignal) => {
 
 export const isDefined = <T>(x: T | undefined | null | ""): x is T =>
   Boolean(x);
+
+export const safeJsonParse = <T>(text: string, withDefault?: T): T | null => {
+  try {
+    return JSON.parse(text);
+  } catch (_) {
+    return withDefault ?? null;
+  }
+};


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Motivation and Context

This PR creates the `CredentialInvalidStatusError` with `errorCode` to track specific errors in 403 and 404 responses during credential and status attestation requests, so that library consumers can extract more details on the failure. Ideally, this error code should be matched with one of the codes found in `issuance_errors_supported` in the EC to get the corresponding message.

> [!NOTE]
> The `CredentialNotEntitledError` and `StatusAttestationInvalid` have been superseded by `CredentialInvalidStatusError` as both those cases can be handled with a single error. 

#### List of Changes

- Renamed `StatusAttestationInvalid` to `CredentialInvalidStatusError` and added `errorCode`
- Removed `CredentialNotEntitledError`
- Added the response body in text format to `UnexpectedStatusCodeError`, otherwise the response body was lost (since this might be an unexpected error, JSON parsing the body might not be 100% safe)
- Throw `CredentialInvalidStatusError` in credential and status attestation requests
- Added an utility function to extract the error message from the EC

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Use a proxy to rewrite the response from the `/status` endpoint. It should return 404 with a body like `{ "error": "credential_revoked" }`.
- Do the same for the `/credential` endpoint. It should return 403 and 404 with a body like `{ "error": "credential_revoked" }`.

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
