### PR TITLE
feat: [SIW-1865] Add wallet instance status API call

### DIFF
--- a/example/src/thunks/instance.ts
+++ b/example/src/thunks/instance.ts
@@ -7,7 +7,10 @@ import {
   getIntegrityContext,
 } from "../utils/integrity";
 import { selectEnv } from "../store/reducers/environment";
-import { instanceReset } from "../store/reducers/instance";
+import {
+  instanceReset,
+  selectInstanceKeyTag,
+} from "../store/reducers/instance";
 import { getEnv } from "../utils/environment";
 import { isAndroid } from "../utils/device";
 
@@ -45,8 +48,14 @@ export const revokeWalletInstanceThunk = createAppAsyncThunk(
   async (_, { getState, dispatch }) => {
     const env = selectEnv(getState());
     const { WALLET_PROVIDER_BASE_URL } = getEnv(env);
+    const integrityKeyTag = selectInstanceKeyTag(getState());
 
-    await WalletInstance.revokeCurrentWalletInstance({
+    if (!integrityKeyTag) {
+      throw new Error("Integrity key not found");
+    }
+
+    await WalletInstance.revokeWalletInstance({
+      id: integrityKeyTag,
       walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
       appFetch,
     });

--- a/openapi/wallet-provider.yaml
+++ b/openapi/wallet-provider.yaml
@@ -45,6 +45,50 @@ paths:
         "500":
           $ref: "#/components/responses/Unexpected"
 
+  /wallet-instances/{id}/status:
+    parameters:
+    - in: path
+      name: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Retrieve a Wallet Instance status
+      operationId: getWalletInstanceStatus
+      responses:
+        "200":
+          description: Wallet Instance status successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WalletInstanceData"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/Unexpected"
+
+    put:
+      summary: Revoke a Wallet Instance
+      operationId: setWalletInstanceStatus
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetWalletInstanceStatusBody"
+      responses:
+        "204":
+          description: Wallet Instance status successfully set
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/Unexpected"
+
   /token:
     description: This is a token endpoint (as defined in RFC 7523 section 4)
     post:
@@ -68,27 +112,9 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          $ref: "#/components/responses/Forbidden"
+          $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
-        "422":
-          $ref: "#/components/responses/UnprocessableContent"
-        "500":
-          $ref: "#/components/responses/Unexpected"
-
-  /wallet-instances/current/status:
-    put:
-      summary: Revoke current Wallet Instance
-      operationId: setCurrentWalletInstanceStatus
-      description: Revoke the current Wallet Instance. If the Wallet Instance is already revoked, the operation will succeed.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SetCurrentWalletInstanceStatusBody"
-      responses:
-        "204":
-          description: Wallet Instance status successfully set
         "422":
           $ref: "#/components/responses/UnprocessableContent"
         "500":
@@ -238,7 +264,7 @@ components:
             problem. It may or may not yield further information if
             dereferenced.
 
-    SetCurrentWalletInstanceStatusBody:
+    SetWalletInstanceStatusBody:
       type: object
       properties:
         status:
@@ -246,3 +272,27 @@ components:
           enum: ["REVOKED"]
       required:
         - status
+
+    WalletInstanceData:
+      description: |-
+        Describes the status of the wallet.
+      type: object
+      properties:
+        id:
+          type: string
+        is_revoked:
+          type: boolean
+        revocation_reason:
+          $ref: "#/components/schemas/RevocationReason"
+      required:
+        - id
+        - is_revoked
+
+    RevocationReason:
+      type: string
+      enum:
+        [
+          "CERTIFICATE_REVOKED_BY_ISSUER",
+          "NEW_WALLET_INSTANCE_CREATED",
+          "REVOKED_BY_USER",
+        ]

--- a/src/client/__tests__/index.test.ts
+++ b/src/client/__tests__/index.test.ts
@@ -1,0 +1,21 @@
+import { interpolateUrl } from "..";
+import type { EndpointParameters } from "../generated/wallet-provider";
+
+type TestCase = [string, EndpointParameters, string];
+
+describe("interpolateUrl", () => {
+  test.each([
+    ["/url/without/params", {}, "/url/without/params"],
+    ["/url/with/{id}/param", { path: { id: "A" } }, "/url/with/A/param"],
+    [
+      "/url/with/{id}/{code}/params",
+      { path: { id: "A", code: "B" } },
+      "/url/with/A/B/params",
+    ],
+  ] as Array<TestCase>)(
+    "it should interpolate %s with %o to %s",
+    (url, params, expected) => {
+      expect(interpolateUrl(url, params)).toEqual(expected);
+    }
+  );
+});

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -2,6 +2,7 @@ import { WalletProviderResponseError } from "../utils/errors";
 import {
   ProblemDetail,
   createApiClient as createWalletProviderApiClient,
+  type EndpointParameters,
 } from "./generated/wallet-provider";
 import { ApiClient as WalletProviderApiClient } from "./generated/wallet-provider";
 
@@ -36,7 +37,7 @@ export const getWalletProviderClient = (context: {
 
   return createWalletProviderApiClient(
     (method, url, params) =>
-      appFetch(url, {
+      appFetch(interpolateUrl(url, params), {
         method,
         body: params ? JSON.stringify(params.body) : undefined,
         headers: {
@@ -53,4 +54,20 @@ export const getWalletProviderClient = (context: {
         }),
     walletProviderBaseUrl
   );
+};
+
+/**
+ * Function to interpolate the url when the request includes path params.
+ * The client generator expects the literal name of the param in the url
+ * and passes the actual values in a separate object.
+ */
+const interpolateUrl = (url: string, params?: EndpointParameters) => {
+  if (!params?.path) return url;
+
+  for (const [key, value] of Object.entries(params.path)) {
+    if (typeof value === "string") {
+      url = url.replace(`{${key}}`, value);
+    }
+  }
+  return url;
 };

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -57,7 +57,7 @@ export const getWalletProviderClient = (context: {
  * The client generator expects the literal name of the param in the url
  * and passes the actual values in a separate object.
  */
-const interpolateUrl = (url: string, params?: EndpointParameters) => {
+export const interpolateUrl = (url: string, params?: EndpointParameters) => {
   if (!params?.path) return url;
 
   for (const [key, value] of Object.entries(params.path)) {

--- a/src/utils/error-codes.ts
+++ b/src/utils/error-codes.ts
@@ -30,7 +30,7 @@ export const WalletProviderResponseErrorCodes = {
   WalletInstanceAttestationIssuingFailed:
     "ERR_IO_WALLET_INSTANCE_ATTESTATION_ISSUING_FAILED",
   /**
-   * An error code thrown when obtaining a wallet instance attestation which fails due to the integrity.
+   * An error code thrown when the requester does not pass the integrity checks when interacting with the Wallet Provider.
    */
   WalletInstanceIntegrityFailed: "ERR_IO_WALLET_INSTANCE_INTEGRITY_FAILED",
   /**

--- a/src/wallet-instance/README.md
+++ b/src/wallet-instance/README.md
@@ -6,7 +6,8 @@ The suggested way to implement this service is to use [io-react-native-integrity
 
 The following methods are available:
 - `createWalletInstance` creates a new wallet instance;
-- `revokeCurrentWalletInstance` revokes the currently valid wallet instance of the user who made the request.
+- `revokeWalletInstance` revokes a wallet instance by ID.
+- `getWalletInstanceStatus` fecthes the status of wallet instance by ID without the need to require an attestation.
 
 Examples are provided as follows:
 

--- a/src/wallet-instance/README.md
+++ b/src/wallet-instance/README.md
@@ -35,12 +35,29 @@ return integrityKeyTag;
 
 The returned `integrityKeyTag` is supposed to be stored and used to verify the integrity of the device in the future when using an `IntegrityContext` object. It must be regenerated if another wallet instance is created.
 
-### Wallet instance revocation
+### Wallet Instance revocation
+
+Revoke a Wallet Instance by ID. The ID matches the hardware/integrity key tag used for creation.
 
 ```ts
 const { WALLET_PROVIDER_BASE_URL } = env;
 
-await WalletInstance.revokeCurrentWalletInstance({
+await WalletInstance.revokeWalletInstance({
+  id: "495e5bec-b93f-4fd7-952a-94b27233abdb"
+  walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
+  appFetch,
+});
+
+```
+### Wallet Instance status
+
+Get the status of a Wallet Instance by ID. The ID matches the hardware/integrity key tag used for creation.
+
+```ts
+const { WALLET_PROVIDER_BASE_URL } = env;
+
+const status = await WalletInstance.getWalletInstanceStatus({
+  id: "495e5bec-b93f-4fd7-952a-94b27233abdb"
   walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
   appFetch,
 });

--- a/src/wallet-instance/README.md
+++ b/src/wallet-instance/README.md
@@ -6,8 +6,8 @@ The suggested way to implement this service is to use [io-react-native-integrity
 
 The following methods are available:
 - `createWalletInstance` creates a new wallet instance;
-- `revokeWalletInstance` revokes a wallet instance by ID.
-- `getWalletInstanceStatus` fecthes the status of wallet instance by ID without the need to require an attestation.
+- `revokeWalletInstance` revokes a wallet instance by ID;
+- `getWalletInstanceStatus` fetches the status of a wallet instance by ID without the need to require an attestation.
 
 Examples are provided as follows:
 

--- a/src/wallet-instance/index.ts
+++ b/src/wallet-instance/index.ts
@@ -1,10 +1,11 @@
 import { getWalletProviderClient } from "../client";
-import type { IntegrityContext } from "..";
 import {
   WalletInstanceCreationError,
   WalletInstanceCreationIntegrityError,
   WalletProviderResponseError,
 } from "../utils/errors";
+import type { WalletInstanceData } from "../client/generated/wallet-provider";
+import type { IntegrityContext } from "..";
 
 export async function createWalletInstance(context: {
   integrityContext: IntegrityContext;
@@ -55,13 +56,36 @@ const handleCreateWalletInstanceError = (e: unknown) => {
   );
 };
 
-export async function revokeCurrentWalletInstance(context: {
+/**
+ * Revoke a Wallet Instance by ID.
+ * @param context.id The Wallet Instance ID. It matches the hardware key tag used for creation.
+ */
+export async function revokeWalletInstance(context: {
+  id: string;
   walletProviderBaseUrl: string;
   appFetch?: GlobalFetch["fetch"];
 }): Promise<void> {
   const api = getWalletProviderClient(context);
 
-  await api.put("/wallet-instances/current/status", {
+  await api.put("/wallet-instances/{id}/status", {
+    path: { id: context.id },
     body: { status: "REVOKED" },
+  });
+}
+
+/**
+ * Get the status of a Wallet Instance by ID.
+ * @param context.id The Wallet Instance ID. It matches the hardware key tag used for creation.
+ * @returns Details on the status of the Wallet Instance
+ */
+export async function getWalletInstanceStatus(context: {
+  id: string;
+  walletProviderBaseUrl: string;
+  appFetch?: GlobalFetch["fetch"];
+}): Promise<WalletInstanceData> {
+  const api = getWalletProviderClient(context);
+
+  return api.get("/wallet-instances/{id}/status", {
+    path: { id: context.id },
   });
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Updated OpenAPI definitions (and removed `/wallet-instances/current/status`)
- Added `getWalletInstanceStatus` method
- Refactored `revokeCurrentWalletInstance` into `revokeWalletInstance` to accept the Wallet Instance ID

#### Motivation and Context

This PR introduces a new function to get the status of a Wallet Instance without requiring an attestation. The function to revoke a Wallet Instance was modified to be consistent with `getWalletInstanceStatus` and require the ID of the instance.

#### How Has This Been Tested?

Used the new API client methods, and tried the other ones to ensure no regressions were introduced.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
