### PR TITLE
fix: [SIW-1785] Avoid multiple CIE completed event

### DIFF
--- a/src/cie/component.tsx
+++ b/src/cie/component.tsx
@@ -97,6 +97,7 @@ const webView = createRef<WebView>();
 export const WebViewComponent = (params: CIEParams) => {
   const [webViewUrl, setWebViewUrl] = React.useState(params.authUrl);
   const [isCardReadingFinished, setCardReadingFinished] = React.useState(false);
+  const cieCompletedEventEmitted = React.useRef(false);
 
   /*
    * Once the reading of the card with NFC is finished, it is necessary
@@ -154,8 +155,11 @@ export const WebViewComponent = (params: CIEParams) => {
        * then the WebView has loaded the page to ask the user for consent,
        * so send the completed event
        * */
-      if (isCardReadingFinished) {
+      if (isCardReadingFinished && !cieCompletedEventEmitted.current) {
         onCieEvent(CieEvent.completed);
+        // This ref prevents the "CIE read completed" event being fired multiple times
+        // when the webview finishes loading the second url.
+        cieCompletedEventEmitted.current = true;
       }
     };
 

--- a/src/cie/component.tsx
+++ b/src/cie/component.tsx
@@ -151,14 +151,15 @@ export const WebViewComponent = (params: CIEParams) => {
         handleOnError(onError)(new Error(eventTitle));
       }
 
-      /* At the end of loading the page, if the card has already been read
+      /**
+       * At the end of loading the page, if the card has already been read
        * then the WebView has loaded the page to ask the user for consent,
-       * so send the completed event
-       * */
+       * so send the completed event.
+       * The ref here prevents the "read completed" event being fired multiple times
+       * when the webview finishes loading the second url.
+       */
       if (isCardReadingFinished && !cieCompletedEventEmitted.current) {
         onCieEvent(CieEvent.completed);
-        // This ref prevents the "CIE read completed" event being fired multiple times
-        // when the webview finishes loading the second url.
         cieCompletedEventEmitted.current = true;
       }
     };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Modified `WebViewComponent` in the CIE's flow.

#### Motivation and Context

This PR addresses the issue of the CIE read `completed` event being fired multiple times, potentially causing unexpected behaviors in a consumer that assumes the event is only emitted once.

#### How Has This Been Tested?

Run the example app and ensure the CIE+PIN identification mode works as expected.

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
