### PR TITLE
feat: [WLEO-218] Introduce unrequestedDisclosures for enhanced disclosure categorization

### DIFF
--- a/src/credential/presentation/07-evaluate-input-descriptor.ts
+++ b/src/credential/presentation/07-evaluate-input-descriptor.ts
@@ -9,7 +9,7 @@ const INDEX_CLAIM_NAME = 1;
 export type EvaluatedDisclosures = {
   requiredDisclosures: DisclosureWithEncoded[];
   optionalDisclosures: DisclosureWithEncoded[];
-  unrequiredDisclosures: DisclosureWithEncoded[];
+  unrequestedDisclosures: DisclosureWithEncoded[];
 };
 
 export type EvaluateInputDescriptorSdJwt4VC = (
@@ -101,7 +101,7 @@ const extractClaimName = (path: string): string | undefined => {
  *   and match any specified JSONPath.
  * - If a field includes a JSON Schema filter, validates the claim value against that schema.
  * - Enforces `limit_disclosure` rules by returning only disclosures, required and optional, matching the specified fields
- *   if set to "required". Otherwise also return the array unrequiredDisclosures with disclosures which can be passed for a particular use case.
+ *   if set to "required". Otherwise also return the array unrequestedDisclosures with disclosures which can be passed for a particular use case.
  * - Throws an error if a required field is invalid or missing.
  *
  * @param inputDescriptor - Describes constraints (fields, filters, etc.) that must be satisfied.
@@ -117,7 +117,7 @@ export const evaluateInputDescriptorForSdJwt4VC: EvaluateInputDescriptorSdJwt4VC
       return {
         requiredDisclosures: [],
         optionalDisclosures: [],
-        unrequiredDisclosures: disclosures,
+        unrequestedDisclosures: disclosures,
       };
     }
     const requiredClaimNames: string[] = [];
@@ -200,7 +200,7 @@ export const evaluateInputDescriptorForSdJwt4VC: EvaluateInputDescriptorSdJwt4VC
       inputDescriptor.constraints.limit_disclosure === "required"
     );
 
-    const unrequiredDisclosures = isNotLimitDisclosure
+    const unrequestedDisclosures = isNotLimitDisclosure
       ? disclosures.filter(
           (disclosure) =>
             !optionalClaimNames.includes(
@@ -213,6 +213,6 @@ export const evaluateInputDescriptorForSdJwt4VC: EvaluateInputDescriptorSdJwt4VC
     return {
       requiredDisclosures,
       optionalDisclosures,
-      unrequiredDisclosures,
+      unrequestedDisclosures,
     };
   };

--- a/src/credential/presentation/__tests__/07-evaluate-input-descriptor.test.ts
+++ b/src/credential/presentation/__tests__/07-evaluate-input-descriptor.test.ts
@@ -33,12 +33,12 @@ describe("evaluateInputDescriptorForSdJwt4VC", () => {
       },
     ];
 
-    const { optionalDisclosures } = evaluateInputDescriptorForSdJwt4VC(
+    const { unrequiredDisclosures } = evaluateInputDescriptorForSdJwt4VC(
       inputDescriptor,
       payloadCredential,
       disclosures
     );
-    expect(optionalDisclosures).toEqual(disclosures);
+    expect(unrequiredDisclosures).toEqual(disclosures);
   });
 
   it("should throw an error if a required field path does not exist", () => {
@@ -104,13 +104,13 @@ describe("evaluateInputDescriptorForSdJwt4VC", () => {
       },
     ];
 
-    const { optionalDisclosures } = evaluateInputDescriptorForSdJwt4VC(
+    const { unrequiredDisclosures } = evaluateInputDescriptorForSdJwt4VC(
       inputDescriptor,
       payloadCredential,
       disclosures
     );
     // Because the field is optional, we keep the original disclosures
-    expect(optionalDisclosures).toEqual(disclosures);
+    expect(unrequiredDisclosures).toEqual(disclosures);
   });
 
   it("should throw an error if filter (JSON Schema) validation fails", () => {
@@ -226,11 +226,12 @@ describe("evaluateInputDescriptorForSdJwt4VC", () => {
       },
     ];
 
-    const { requiredDisclosures } = evaluateInputDescriptorForSdJwt4VC(
-      inputDescriptor,
-      payloadCredential,
-      disclosures
-    );
+    const { requiredDisclosures, unrequiredDisclosures } =
+      evaluateInputDescriptorForSdJwt4VC(
+        inputDescriptor,
+        payloadCredential,
+        disclosures
+      );
 
     // Should only keep the disclosures for given_name
     const expected = [
@@ -241,6 +242,7 @@ describe("evaluateInputDescriptorForSdJwt4VC", () => {
     ];
 
     expect(requiredDisclosures).toStrictEqual(expected);
+    expect(unrequiredDisclosures).toStrictEqual([]);
   });
 
   it("should return all disclosures if limit_disclosure is not set or not 'required'", () => {
@@ -275,13 +277,13 @@ describe("evaluateInputDescriptorForSdJwt4VC", () => {
     ];
 
     // limit_disclosure is undefined or not "required", so we return all disclosures
-    const { requiredDisclosures, optionalDisclosures } =
+    const { requiredDisclosures, unrequiredDisclosures } =
       evaluateInputDescriptorForSdJwt4VC(
         inputDescriptor,
         payloadCredential,
         disclosures
       );
     expect(requiredDisclosures).toEqual([disclosures[0]]);
-    expect(optionalDisclosures).toEqual([disclosures[1]]);
+    expect(unrequiredDisclosures).toEqual([disclosures[1]]);
   });
 });

--- a/src/credential/presentation/__tests__/07-evaluate-input-descriptor.test.ts
+++ b/src/credential/presentation/__tests__/07-evaluate-input-descriptor.test.ts
@@ -33,12 +33,12 @@ describe("evaluateInputDescriptorForSdJwt4VC", () => {
       },
     ];
 
-    const { unrequiredDisclosures } = evaluateInputDescriptorForSdJwt4VC(
+    const { unrequestedDisclosures } = evaluateInputDescriptorForSdJwt4VC(
       inputDescriptor,
       payloadCredential,
       disclosures
     );
-    expect(unrequiredDisclosures).toEqual(disclosures);
+    expect(unrequestedDisclosures).toEqual(disclosures);
   });
 
   it("should throw an error if a required field path does not exist", () => {
@@ -104,13 +104,13 @@ describe("evaluateInputDescriptorForSdJwt4VC", () => {
       },
     ];
 
-    const { unrequiredDisclosures } = evaluateInputDescriptorForSdJwt4VC(
+    const { unrequestedDisclosures } = evaluateInputDescriptorForSdJwt4VC(
       inputDescriptor,
       payloadCredential,
       disclosures
     );
     // Because the field is optional, we keep the original disclosures
-    expect(unrequiredDisclosures).toEqual(disclosures);
+    expect(unrequestedDisclosures).toEqual(disclosures);
   });
 
   it("should throw an error if filter (JSON Schema) validation fails", () => {
@@ -226,7 +226,7 @@ describe("evaluateInputDescriptorForSdJwt4VC", () => {
       },
     ];
 
-    const { requiredDisclosures, unrequiredDisclosures } =
+    const { requiredDisclosures, unrequestedDisclosures } =
       evaluateInputDescriptorForSdJwt4VC(
         inputDescriptor,
         payloadCredential,
@@ -242,7 +242,7 @@ describe("evaluateInputDescriptorForSdJwt4VC", () => {
     ];
 
     expect(requiredDisclosures).toStrictEqual(expected);
-    expect(unrequiredDisclosures).toStrictEqual([]);
+    expect(unrequestedDisclosures).toStrictEqual([]);
   });
 
   it("should return all disclosures if limit_disclosure is not set or not 'required'", () => {
@@ -277,13 +277,13 @@ describe("evaluateInputDescriptorForSdJwt4VC", () => {
     ];
 
     // limit_disclosure is undefined or not "required", so we return all disclosures
-    const { requiredDisclosures, unrequiredDisclosures } =
+    const { requiredDisclosures, unrequestedDisclosures } =
       evaluateInputDescriptorForSdJwt4VC(
         inputDescriptor,
         payloadCredential,
         disclosures
       );
     expect(requiredDisclosures).toEqual([disclosures[0]]);
-    expect(unrequiredDisclosures).toEqual([disclosures[1]]);
+    expect(unrequestedDisclosures).toEqual([disclosures[1]]);
   });
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
During evaluate-input-descriptor phase, introduced a new property `unrequestedDisclosures` to the EvaluatedDisclosures type to categorize disclosures that are neither required nor optional. When limit_disclosure is set to `required`, unrequestedDisclosures is empty, otherwise it contains disclosures that are not requested inside presentation_definition.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The introduction of `unrequestedDisclosures` addresses the need for a more granular categorization of disclosures in the credential presentation process. Previously, disclosures were limited to being either required or optional, which did not account for scenarios where certain disclosures should neither be mandatory nor suggested.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
