### PR TITLE
fix:[WLEO-277] State must be optional in Request Object and Presentation Response

### DIFF
--- a/src/credential/presentation/08-send-authorization-response.ts
+++ b/src/credential/presentation/08-send-authorization-response.ts
@@ -60,7 +60,7 @@ export const buildDirectPostBody = async (
   payload: DirectAuthorizationBodyPayload
 ): Promise<string> => {
   const formUrlEncodedBody = new URLSearchParams({
-    state: requestObject.state,
+    ...(requestObject.state ? { state: requestObject.state } : {}),
     ...Object.fromEntries(
       Object.entries(payload).map(([key, value]) => {
         return [
@@ -116,7 +116,7 @@ export const buildDirectPostJwtBody = async (
   // Build the x-www-form-urlencoded form body
   const formBody = new URLSearchParams({
     response: encryptedResponse,
-    state: requestObject.state,
+    ...(requestObject.state ? { state: requestObject.state } : {}),
   });
   return formBody.toString();
 };

--- a/src/credential/presentation/types.ts
+++ b/src/credential/presentation/types.ts
@@ -82,7 +82,7 @@ export const RequestObject = z.object({
   iss: z.string().optional(), //optional by RFC 7519, mandatory for Potential
   iat: UnixTime.optional(),
   exp: UnixTime.optional(),
-  state: z.string(),
+  state: z.string().optional(),
   nonce: z.string(),
   response_uri: z.string(),
   response_type: z.literal("vp_token"),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- `state` claim is now optional in Request Object schema
- `state` will be added in remote presentation if it is present in  Request Object

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR aims to fix the mandatory of `state` claim in  Request Object. [OID4VP](https://openid.net/specs/openid-4-verifiable-presentations-1_0-20.html#name-authorization-request) and I[talian Specs](https://italia.github.io/eudi-wallet-it-docs/v0.9.2/en/relying-party-solution.html#authorization-request-details) mark it as optional or recommended, not mandatory.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
During Interop Test in Utrecht, a Relying Party did not include state inside its Request Object. You can try to test when it is present at https://verifier.eudiw.dev/.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
