### PR TITLE
feat: [SIW-2196] Update ObtainCredential for IT Wallet transition

### DIFF
--- a/src/credential/issuance/06-obtain-credential.ts
+++ b/src/credential/issuance/06-obtain-credential.ts
@@ -27,7 +27,8 @@ export type ObtainCredential = (
     dPopCryptoContext: CryptoContext;
     credentialCryptoContext: CryptoContext;
     appFetch?: GlobalFetch["fetch"];
-  }
+  },
+  operationType?: "reissuing"
 ) => Promise<CredentialResponse>;
 
 export const createNonceProof = async (
@@ -73,7 +74,8 @@ export const obtainCredential: ObtainCredential = async (
   accessToken,
   clientId,
   credentialDefinition,
-  context
+  context,
+  operationType
 ) => {
   const {
     credentialCryptoContext,
@@ -138,6 +140,7 @@ export const obtainCredential: ObtainCredential = async (
       "Content-Type": "application/json",
       DPoP: tokenRequestSignedDPop,
       Authorization: `${accessToken.token_type} ${accessToken.access_token}`,
+      ...(operationType && { operationType }),
     },
     body: JSON.stringify(credentialRequestFormBody),
   })

--- a/src/credential/issuance/06-obtain-credential.ts
+++ b/src/credential/issuance/06-obtain-credential.ts
@@ -140,7 +140,7 @@ export const obtainCredential: ObtainCredential = async (
       "Content-Type": "application/json",
       DPoP: tokenRequestSignedDPop,
       Authorization: `${accessToken.token_type} ${accessToken.access_token}`,
-      ...(operationType && { operationType }),
+      ...(operationType === "reissuing" && { operationType }),
     },
     body: JSON.stringify(credentialRequestFormBody),
   })

--- a/src/credential/issuance/__tests__/06-obtain-credential.test.ts
+++ b/src/credential/issuance/__tests__/06-obtain-credential.test.ts
@@ -3,6 +3,7 @@ import { obtainCredential } from "../06-obtain-credential";
 import type { TokenResponse } from "../types";
 import type { AuthorizationDetail } from "src/utils/par";
 import type { CryptoContext } from "@pagopa/io-react-native-jwt";
+import process from "node:process";
 
 describe("obtainCredential", () => {
   let mockFetch: jest.Mock;
@@ -19,6 +20,8 @@ describe("obtainCredential", () => {
   const mockClientId = "client_id";
 
   beforeEach(() => {
+    process.env.TOKEN_TYPE = "DPoP";
+    process.env.ACCESS_TOKEN = "mock_access_token";
     mockFetch = jest.fn().mockResolvedValue({
       status: 200,
       json: jest.fn().mockResolvedValue({
@@ -63,8 +66,8 @@ describe("obtainCredential", () => {
     } as CredentialIssuerEntityConfiguration["payload"]["metadata"];
 
     mockAccessToken = {
-      access_token: "mock_access_token",
-      token_type: "DPoP",
+      access_token: process.env.ACCESS_TOKEN,
+      token_type: process.env.TOKEN_TYPE,
       c_nonce: "mock_nonce",
       c_nonce_expires_in: 3600,
       expires_in: 3600,

--- a/src/credential/issuance/__tests__/06-obtain-credential.test.ts
+++ b/src/credential/issuance/__tests__/06-obtain-credential.test.ts
@@ -1,0 +1,121 @@
+import type { CredentialIssuerEntityConfiguration } from "src/trust/types";
+import { obtainCredential } from "../06-obtain-credential";
+import type { TokenResponse } from "../types";
+import type { AuthorizationDetail } from "src/utils/par";
+import type { CryptoContext } from "@pagopa/io-react-native-jwt";
+
+describe("obtainCredential", () => {
+  let mockFetch: jest.Mock;
+  let mockGetPublicKey: jest.Mock;
+  let mockGetSignature: jest.Mock;
+  let mockContext: {
+    credentialCryptoContext: CryptoContext;
+    dPopCryptoContext: CryptoContext;
+    appFetch: jest.Mock;
+  };
+  let mockCredentialDefinition: AuthorizationDetail;
+  let mockIssuerConf: CredentialIssuerEntityConfiguration["payload"]["metadata"];
+  let mockAccessToken: TokenResponse;
+  const mockClientId = "client_id";
+
+  beforeEach(() => {
+    mockFetch = jest.fn().mockResolvedValue({
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        c_nonce: "mock_nonce",
+        c_nonce_expires_in: 3600,
+        credential: "mock_credential",
+        format: "vc+sd-jwt",
+      }),
+    });
+    global.fetch = mockFetch;
+
+    mockGetPublicKey = jest.fn().mockResolvedValue({
+      kty: "RSA",
+      n: "mockModulus",
+      e: "AQAB",
+      alg: "RS256",
+    });
+
+    mockGetSignature = jest.fn().mockResolvedValue("mockSignature");
+
+    const createCryptoContext = () => ({
+      getPublicKey: mockGetPublicKey,
+      getSignature: mockGetSignature,
+    });
+
+    mockContext = {
+      credentialCryptoContext: createCryptoContext(),
+      dPopCryptoContext: createCryptoContext(),
+      appFetch: mockFetch,
+    };
+
+    mockCredentialDefinition = {
+      credential_configuration_id: "mock_credential_configuration_id",
+      format: "vc+sd-jwt",
+      type: "openid_credential",
+    };
+
+    mockIssuerConf = {
+      openid_credential_issuer: {
+        credential_endpoint: "https://issuer.example.com/credential",
+      },
+    } as CredentialIssuerEntityConfiguration["payload"]["metadata"];
+
+    mockAccessToken = {
+      access_token: "mock_access_token",
+      token_type: "DPoP",
+      c_nonce: "mock_nonce",
+      c_nonce_expires_in: 3600,
+      expires_in: 3600,
+      authorization_details: [
+        {
+          credential_configuration_id: "mock_credential_configuration_id",
+          format: "vc+sd-jwt",
+          type: "openid_credential",
+        },
+      ],
+    };
+  });
+
+  it("should not include operationType in the header when it is not provided", async () => {
+    await obtainCredential(
+      mockIssuerConf,
+      mockAccessToken,
+      mockClientId,
+      mockCredentialDefinition,
+      mockContext
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://issuer.example.com/credential",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.not.objectContaining({
+          operationType: expect.any(String),
+        }),
+      })
+    );
+  });
+
+  it("should include operationType in the header when it is provided", async () => {
+    await obtainCredential(
+      mockIssuerConf,
+      mockAccessToken,
+      mockClientId,
+      mockCredentialDefinition,
+      mockContext,
+      "reissuing"
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://issuer.example.com/credential",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          operationType: "reissuing",
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added an optional parameter `operationType` to the `obtainCredential` method to distinguish the issuing phase
- Added `operationType` to the `header` in the `/credential` request for the `re-issuing` flow

<!--- Describe your changes in detail -->

#### Motivation and Context

This PR aims to update the `obtainCredential` method for the transition from Documenti su IO to IT Wallet.

It is essential to distinguish between a standard `issuing` request and a `re-issuing` request.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

It is currently not possible to test the credential flow in the re-issuing mode

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
