### PR TITLE
chore: [SIW-2197] Make `idphint` parameter optional for auth request url

### DIFF
--- a/src/credential/issuance/04-complete-user-authorization.ts
+++ b/src/credential/issuance/04-complete-user-authorization.ts
@@ -49,7 +49,7 @@ export type BuildAuthorizationUrl = (
   issuerRequestUri: Out<StartUserAuthorization>["issuerRequestUri"],
   clientId: Out<StartUserAuthorization>["clientId"],
   issuerConf: Out<EvaluateIssuerTrust>["issuerConf"],
-  idpHint: string
+  idpHint?: string
 ) => Promise<{
   authUrl: string;
 }>;
@@ -60,7 +60,7 @@ export type BuildAuthorizationUrl = (
  * @param issuerRequestUri the URI of the issuer where the request is sent
  * @param clientId Identifies the current client across all the requests of the issuing flow returned by {@link startUserAuthorization}
  * @param issuerConf The issuer configuration returned by {@link evaluateIssuerTrust}
- * @param idpHint Unique identifier of the IDP selected by the user
+ * @param idpHint Unique identifier of the IDP selected by the user (optional)
  * @returns An object containing the authorization URL
  */
 export const buildAuthorizationUrl: BuildAuthorizationUrl = async (
@@ -75,8 +75,11 @@ export const buildAuthorizationUrl: BuildAuthorizationUrl = async (
   const params = new URLSearchParams({
     client_id: clientId,
     request_uri: issuerRequestUri,
-    idphint: idpHint,
   });
+
+  if (idpHint) {
+    params.append("idphint", idpHint);
+  }
 
   const authUrl = `${authzRequestEndpoint}?${params}`;
 

--- a/src/credential/issuance/__tests__/04-complete-user-authorization.test.ts
+++ b/src/credential/issuance/__tests__/04-complete-user-authorization.test.ts
@@ -15,9 +15,8 @@ describe("authorizeUserWithQueryMode", () => {
     };
     const authRedirectUrl = `test://cb?code=abcdefg&state=123456&iss=123456`;
 
-    const authResParsed = await completeUserAuthorizationWithQueryMode(
-      authRedirectUrl
-    );
+    const authResParsed =
+      await completeUserAuthorizationWithQueryMode(authRedirectUrl);
 
     expect(authResParsed).toMatchObject(authRes);
   });


### PR DESCRIPTION
#### List of Changes

- made the `idpHint` parameter in the `buildAuthorizationUrl` function optional by updating its type definition and usage.
- added tests for `buildAuthorizationUrl` function

#### Motivation and Context

To obtain an L3 PID, the `idphint` parameter must be omitted from the authentication request URL.
This pull request updates the `buildAuthorizationUrl` function to make the idpHint parameter optional, allowing authentication requests to be generated without explicitly setting an IdP hint when necessary.

#### How Has This Been Tested?

Unit tests

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
