### PR TITLE
feat: [WLEO-345] Prioritize EC keys first P256 during Remote Presentation enc

### DIFF
--- a/src/credential/presentation/08-send-authorization-response.ts
+++ b/src/credential/presentation/08-send-authorization-response.ts
@@ -30,6 +30,9 @@ export const AuthorizationResponse = z.object({
  * Selects a public key (with `use = enc`) from the set of JWK keys
  * offered by the Relying Party (RP) for encryption.
  *
+ * Preference is given to EC keys (P-256 or P-384), followed by RSA keys,
+ * based on compatibility and common usage for encryption.
+ *
  * @param rpJwkKeys - The array of JWKs retrieved from the RP entity configuration.
  * @returns The first suitable public key found in the list.
  * @throws {NoSuitableKeysFoundInEntityConfiguration} If no suitable encryption key is found.

--- a/src/credential/presentation/08-send-authorization-response.ts
+++ b/src/credential/presentation/08-send-authorization-response.ts
@@ -113,7 +113,6 @@ export const buildDirectPostJwtBody = async (
     ...payload,
   });
 
-  // Choose a suitable RSA public key for encryption
   const encPublicJwk = choosePublicKeyToEncrypt(jwkKeys);
   // Encrypt the authorization payload
   const { client_metadata } = requestObject;

--- a/src/credential/presentation/__tests__/08-send-authorization-response.test.ts
+++ b/src/credential/presentation/__tests__/08-send-authorization-response.test.ts
@@ -247,6 +247,16 @@ describe("sendAuthorizationErrorResponse", () => {
     });
   });
 
+  it('should choose the first EC key with "enc" use from the list', () => {
+    const mockJwKeys: any = [
+      { kid: "rsa-key-enc", use: "enc", kty: "RSA" },
+      { kid: "ec-b-key-enc", use: "enc", kty: "EC", crv: "B-256" },
+      { kid: "ec-key-enc", use: "enc", kty: "EC", crv: "P-256" },
+    ];
+    const encPublicJwk = choosePublicKeyToEncrypt(mockJwKeys);
+    expect(encPublicJwk).toEqual(mockJwKeys[2]);
+  });
+
   it("should send an error code building the body using buildDirectPostBody", async () => {
     const res = await sendAuthorizationErrorResponse(
       mockRequestObject as any,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Updated `choosePublicKeyToEncrypt` function to prioritize **EC** keys (P-256, P-384) over **RSA** keys when selecting encryption keys from the JWKS.
- Filtered keys by use: "enc" and sorted them by type and curve support.
- Added a new unit test to verify that the function selects the first supported EC key.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change ensures compatibility with `io-react-native-jwt`, which guarantees supports only for EC encryption keys with curves `P-256` and `P-384`. The previous implementation defaulted to the first enc key without prioritizing supported types, which could lead to runtime errors or unexpected behavior. By explicitly preferring compatible EC keys, we improve reliability and interoperability with supported clients.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
