### PR TITLE
chore: [SIW-2287] Use snake case for presentation parameters in `startFlowFromQR`

### DIFF
--- a/example/src/thunks/presentation.ts
+++ b/example/src/thunks/presentation.ts
@@ -59,37 +59,28 @@ export const remoteCrossDevicePresentationThunk = createAppAsyncThunk<
   if (!walletInstanceAttestation) {
     throw new Error("Wallet Instance Attestation not found");
   }
-  const qrcode = args.qrcode;
-  const url = new URL(qrcode);
-
-  const requestUri = url.searchParams.get("request_uri");
-  const clientId = url.searchParams.get("client_id");
-  const state = url.searchParams.get("state");
-  const requestUriMethod = (url.searchParams.get("request_uri_method") ??
-    "get") as "get" | "post";
-
-  if (!requestUri || !clientId) {
-    throw new Error("Invalid presentation link");
-  }
+  const url = new URL(args.qrcode);
 
   const qrParams = Credential.Presentation.startFlowFromQR({
-    requestUri,
-    clientId,
-    requestUriMethod,
-    ...(state && { state }),
+    request_uri: url.searchParams.get("request_uri"),
+    client_id: url.searchParams.get("client_id"),
+    state: url.searchParams.get("state"),
+    request_uri_method: url.searchParams.get("request_uri_method") as
+      | "get"
+      | "post",
   });
 
   const { rpConf, subject } =
-    await Credential.Presentation.evaluateRelyingPartyTrust(qrParams.clientId);
+    await Credential.Presentation.evaluateRelyingPartyTrust(qrParams.client_id);
 
   const { requestObjectEncodedJwt } =
-    await Credential.Presentation.getRequestObject(qrParams.requestUri);
+    await Credential.Presentation.getRequestObject(qrParams.request_uri);
 
   const { requestObject } = await Credential.Presentation.verifyRequestObject(
     requestObjectEncodedJwt,
     {
       rpConf,
-      clientId: qrParams.clientId,
+      clientId: qrParams.client_id,
       rpSubject: subject,
       state: qrParams.state,
     }

--- a/src/credential/presentation/01-start-flow.ts
+++ b/src/credential/presentation/01-start-flow.ts
@@ -2,9 +2,9 @@ import * as z from "zod";
 import { InvalidQRCodeError } from "./errors";
 
 const PresentationParams = z.object({
-  clientId: z.string().nonempty(),
-  requestUri: z.string().url(),
-  requestUriMethod: z.enum(["get", "post"]),
+  client_id: z.string().nonempty(),
+  request_uri: z.string().url(),
+  request_uri_method: z.enum(["get", "post"]),
   state: z.string().optional(),
 });
 export type PresentationParams = z.infer<typeof PresentationParams>;
@@ -13,24 +13,25 @@ export type PresentationParams = z.infer<typeof PresentationParams>;
  * The beginning of the presentation flow.
  * To be implemented accordind to the user touchpoint
  *
- * @param params Presentation parameters, depending on the starting touchoint
+ * @param params Presentation parameters, depending on the starting touchpoint
  * @returns The url for the Relying Party to connect with
  */
-export type StartFlow = (
-  params: Partial<PresentationParams>
-) => PresentationParams;
+export type StartFlow = (params: {
+  [K in keyof PresentationParams]?: PresentationParams[K] | null;
+}) => PresentationParams;
 
 /**
- * Start a presentation flow by decoding an incoming QR-code
+ * Start a presentation flow by validating the required parameters.
+ * Parameters are extracted from a url encoded in a QR code or in a deep link.
  *
- * @param params The encoded QR-code content
+ * @param params The parameters to be validated
  * @returns The url for the Relying Party to connect with
- * @throws If the provided qr code fails to be decoded
+ * @throws If the provided parameters are not valid
  */
 export const startFlowFromQR: StartFlow = (params) => {
   const result = PresentationParams.safeParse({
     ...params,
-    requestUriMethod: params.requestUriMethod ?? "get",
+    request_uri_method: params.request_uri_method ?? "get",
   });
 
   if (result.success) {

--- a/src/credential/presentation/03-get-request-object.ts
+++ b/src/credential/presentation/03-get-request-object.ts
@@ -1,9 +1,8 @@
-import { hasStatusOrThrow, type Out } from "../../utils/misc";
-import type { StartFlow } from "./01-start-flow";
+import { hasStatusOrThrow } from "../../utils/misc";
 import { RequestObjectWalletCapabilities } from "./types";
 
 export type GetRequestObject = (
-  requestUri: Out<StartFlow>["requestUri"],
+  requestUri: string,
   context?: {
     appFetch?: GlobalFetch["fetch"];
     walletCapabilities?: RequestObjectWalletCapabilities;

--- a/src/credential/presentation/README.md
+++ b/src/credential/presentation/README.md
@@ -15,10 +15,11 @@ sequenceDiagram
   O->>+I: QR-CODE: Authorization Request (`request_uri`)
   I->>+O: GET: Verifier's Entity Configuration
   O->>+I: Respond with metadata (including public keys)
-  I->>+O: GET: Request Object, resolved from the `request_uri`
+  I->>+O: GET: Request Object, resolved from `request_uri`
   O->>+I: Respond with the Request Object
-  I->>+O: POST: VP token encrypted response
-  O->>+I: Redirect: Authorization Response
+  I->>+I: Validate Request Object and give consent
+  I->>+O: POST: Authorization Response with encrypted VP token
+  O->>+I: Respond with optional `redirect_uri`
 ```
 
 ## Mapped results
@@ -42,23 +43,23 @@ const qrCodeParams = decodeQrCode(qrCode)
 
 // Start the issuance flow
 const {
-  requestUri,
-  clientId,
-  requestUriMethod,
+  request_uri,
+  client_id,
+  request_uri_method,
   state
 } = Credential.Presentation.startFlowFromQR(qrCodeParams);
 
 // Get the Relying Party's Entity Configuration and evaluate trust
-const { rpConf } = await Credential.Presentation.evaluateRelyingPartyTrust(clientId);
+const { rpConf } = await Credential.Presentation.evaluateRelyingPartyTrust(client_id);
 
 // Get the Request Object from the RP
 const { requestObjectEncodedJwt } =
-  await Credential.Presentation.getRequestObject(requestUri);
+  await Credential.Presentation.getRequestObject(request_uri);
 
 // Validate the Request Object
 const { requestObject } = await Credential.Presentation.verifyRequestObject(
   requestObjectEncodedJwt,
-  { clientId, rpConf }
+  { clientId: client_id, rpConf }
 );
 
 // All the credentials that might be requested by the Relying Party

--- a/src/credential/presentation/__tests__/01-start-flow.test.ts
+++ b/src/credential/presentation/__tests__/01-start-flow.test.ts
@@ -3,9 +3,9 @@ import { startFlowFromQR } from "../01-start-flow";
 import { InvalidQRCodeError } from "../errors";
 
 describe("startFlowFromQR", () => {
-  const requestUri = "https://request.uri";
-  const clientId = "client123";
-  const requestUriMethod = "get";
+  const request_uri = "https://request.uri";
+  const client_id = "client123";
+  const request_uri_method = "get";
   const state = "state123";
 
   beforeEach(() => {
@@ -14,29 +14,43 @@ describe("startFlowFromQR", () => {
 
   it("should successfully decode a valid QR code", () => {
     const result = startFlowFromQR({
-      requestUri,
-      clientId,
-      requestUriMethod,
+      request_uri,
+      client_id,
+      request_uri_method,
       state,
     });
 
     expect(result).toEqual({
-      requestUri,
-      clientId,
-      requestUriMethod,
+      request_uri,
+      client_id,
+      request_uri_method,
       state,
     });
   });
 
   it("should throw InvalidQRCodeError for invalid request_uri ", () => {
     expect(() =>
-      startFlowFromQR({ requestUri: "test", requestUriMethod, clientId })
+      startFlowFromQR({ request_uri_method, client_id, request_uri: "test" })
     ).toThrow(InvalidQRCodeError);
   });
 
   it("should throw InvalidQRCodeError for invalid client_id", () => {
     expect(() =>
-      startFlowFromQR({ requestUri, requestUriMethod, clientId: "" })
+      startFlowFromQR({ request_uri, request_uri_method, client_id: "" })
     ).toThrow(InvalidQRCodeError);
+  });
+
+  it("should throw InvalidQRCodeError for nullable parameters ", () => {
+    expect(() =>
+      startFlowFromQR({
+        request_uri: null,
+        request_uri_method: null,
+        client_id: null,
+      })
+    ).toThrow(InvalidQRCodeError);
+  });
+
+  it("should throw InvalidQRCodeError for missing parameters ", () => {
+    expect(() => startFlowFromQR({ request_uri })).toThrow(InvalidQRCodeError);
   });
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Use snake case for the presentation parameters in `startFlowFromQR`
- Updated tests

#### Motivation and Context

This PR changes the case of input parameters and validated parameters to `snake_case` in `startFlowFromQR`. The rationale is to provide consistency when validating the raw parameters extracted from a QR code or a deep link, without additional mapping between `snake_case` and `camelCase`.

`startFlowFromQR` has also been updated to accept null values, moving all the validation to the function, even for missing/nullable values.

#### How Has This Been Tested?

Start a presentation flow with the example app. Everything should work as before.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
