### PR TITLE
feat: [SIW-2159] Handle presentation errors

### DIFF
--- a/example/src/screens/PresentationScreen.tsx
+++ b/example/src/screens/PresentationScreen.tsx
@@ -42,6 +42,17 @@ export const PresentationScreen = () => {
         isPresent: !!presentationDetails.redirectUri,
         successMessage: "OK",
       },
+      {
+        title: "PID Remote Cross-Device (Refuse)",
+        onPress: () =>
+          navigation.navigate("QrScanner", {
+            presentationBehavior: "refusalState",
+          }),
+        isLoading: refusalPresentationState.isLoading,
+        hasError: refusalPresentationState.hasError,
+        isDone: refusalPresentationState.isDone,
+        icon: "qrCode",
+      },
     ],
     [
       navigation,
@@ -49,6 +60,9 @@ export const PresentationScreen = () => {
       acceptancePresentationState.isDone,
       acceptancePresentationState.isLoading,
       presentationDetails.redirectUri,
+      refusalPresentationState.hasError,
+      refusalPresentationState.isDone,
+      refusalPresentationState.isLoading,
     ]
   );
 

--- a/example/src/thunks/presentation.ts
+++ b/example/src/thunks/presentation.ts
@@ -108,6 +108,10 @@ export const remoteCrossDevicePresentationThunk = createAppAsyncThunk<
       .map((c) => [c.keyTag, c.credential]),
   ] as [string, string][];
 
+  if (requestObject.dcql_query && args.allowed === "refusalState") {
+    return processRefusedPresentation(requestObject);
+  }
+
   if (requestObject.dcql_query) {
     return processPresentation(requestObject, rpConf, credentialsSdJwt);
   }
@@ -211,4 +215,17 @@ const processPresentation: ProcessPresentation = async (
     requestObject,
     requestedClaims: credentialsToPresent.flatMap((c) => c.requestedClaims),
   };
+};
+
+// Mock an error in the presentation flow
+const processRefusedPresentation = async (requestObject: RequestObject) => {
+  const authResponse =
+    await Credential.Presentation.sendAuthorizationErrorResponse(
+      requestObject,
+      {
+        error: "invalid_request_object",
+        errorDescription: "Mock error during request object validation",
+      }
+    );
+  return { authResponse, requestObject, requestedClaims: [] };
 };

--- a/example/src/thunks/presentation.ts
+++ b/example/src/thunks/presentation.ts
@@ -210,13 +210,14 @@ const processPresentation: ProcessPresentation = async (
 
 // Mock an error in the presentation flow
 const processRefusedPresentation = async (requestObject: RequestObject) => {
+  const { state, response_uri } = requestObject;
+
   const authResponse =
-    await Credential.Presentation.sendAuthorizationErrorResponse(
-      requestObject,
-      {
-        error: "invalid_request_object",
-        errorDescription: "Mock error during request object validation",
-      }
-    );
+    await Credential.Presentation.sendAuthorizationErrorResponse({
+      state,
+      responseUri: response_uri,
+      error: "invalid_request_object",
+      errorDescription: "Mock error during request object validation",
+    });
   return { authResponse, requestObject, requestedClaims: [] };
 };

--- a/example/src/thunks/presentation.ts
+++ b/example/src/thunks/presentation.ts
@@ -210,14 +210,13 @@ const processPresentation: ProcessPresentation = async (
 
 // Mock an error in the presentation flow
 const processRefusedPresentation = async (requestObject: RequestObject) => {
-  const { state, response_uri } = requestObject;
-
   const authResponse =
-    await Credential.Presentation.sendAuthorizationErrorResponse({
-      state,
-      responseUri: response_uri,
-      error: "invalid_request_object",
-      errorDescription: "Mock error during request object validation",
-    });
+    await Credential.Presentation.sendAuthorizationErrorResponse(
+      requestObject,
+      {
+        error: "invalid_request_object",
+        errorDescription: "Mock error during request object validation",
+      }
+    );
   return { authResponse, requestObject, requestedClaims: [] };
 };

--- a/src/credential/presentation/03-get-request-object.ts
+++ b/src/credential/presentation/03-get-request-object.ts
@@ -1,3 +1,4 @@
+import { RelyingPartyResponseError } from "../../utils/errors";
 import { hasStatusOrThrow, type Out } from "../../utils/misc";
 import type { StartFlow } from "./01-start-flow";
 import { RequestObjectWalletCapabilities } from "./types";
@@ -41,7 +42,7 @@ export const getRequestObject: GetRequestObject = async (
       },
       body: formUrlEncodedBody.toString(),
     })
-      .then(hasStatusOrThrow(200))
+      .then(hasStatusOrThrow(200, RelyingPartyResponseError))
       .then((res) => res.text());
 
     return {
@@ -52,7 +53,7 @@ export const getRequestObject: GetRequestObject = async (
   const requestObjectEncodedJwt = await appFetch(requestUri, {
     method: "GET",
   })
-    .then(hasStatusOrThrow(200))
+    .then(hasStatusOrThrow(200, RelyingPartyResponseError))
     .then((res) => res.text());
 
   return {

--- a/src/credential/presentation/05-verify-request-object.ts
+++ b/src/credential/presentation/05-verify-request-object.ts
@@ -84,7 +84,7 @@ const validateRequestObjectShape = (payload: unknown): RequestObject => {
 };
 
 /**
- * Get the public key to verify the Request Object's signature from the Relying Party'EC.
+ * Get the public key to verify the Request Object's signature from the Relying Party's EC.
  *
  * @param rpConf The Relying Party'EC
  * @param kid The identifier of the key to find

--- a/src/credential/presentation/05-verify-request-object.ts
+++ b/src/credential/presentation/05-verify-request-object.ts
@@ -86,7 +86,7 @@ const validateRequestObjectShape = (payload: unknown): RequestObject => {
 /**
  * Get the public key to verify the Request Object's signature from the Relying Party's EC.
  *
- * @param rpConf The Relying Party'EC
+ * @param rpConf The Relying Party's EC
  * @param kid The identifier of the key to find
  * @returns The corresponding public key to verify the signature
  * @throws {InvalidRequestObjectError} when the key cannot be found

--- a/src/credential/presentation/08-send-authorization-response.ts
+++ b/src/credential/presentation/08-send-authorization-response.ts
@@ -59,21 +59,21 @@ export const choosePublicKeyToEncrypt = (
 /**
  * Builds a URL-encoded form body for a direct POST response using JWT encryption.
  *
- * @param jwkKeys - Array of JWKs from the Relying Party for encryption.
- * @param requestObject - Contains state, nonce, and other relevant info.
  * @param payload - Object that contains the VP token to encrypt and the mapping of the credential disclosures
+ * @param rpConf - The Relying Party's configuration to get the keys for encryption
+ * @param state - Optional state
  * @returns A URL-encoded string for an `application/x-www-form-urlencoded` POST body, where `response` contains the encrypted JWE.
  */
 export const buildDirectPostJwtBody = async (
-  requestObject: Out<VerifyRequestObject>["requestObject"],
+  payload: DirectAuthorizationBodyPayload,
   rpConf: RelyingPartyEntityConfiguration["payload"]["metadata"],
-  payload: DirectAuthorizationBodyPayload
+  state?: string
 ): Promise<string> => {
   type Jwe = ConstructorParameters<typeof EncryptJwe>[1];
 
   // Prepare the authorization response payload to be encrypted
   const authzResponsePayload = JSON.stringify({
-    state: requestObject.state,
+    state,
     ...payload,
   });
   // Choose a suitable public key for encryption
@@ -99,7 +99,7 @@ export const buildDirectPostJwtBody = async (
   // Build the x-www-form-urlencoded form body
   const formBody = new URLSearchParams({
     response: encryptedResponse,
-    ...(requestObject.state ? { state: requestObject.state } : {}),
+    ...(state ? { state } : {}),
   });
   return formBody.toString();
 };
@@ -107,16 +107,16 @@ export const buildDirectPostJwtBody = async (
 /**
  * Builds a URL-encoded form body for a direct POST response without encryption.
  *
- * @param requestObject - Contains state, nonce, and other relevant info.
  * @param payload - Object that contains either the VP token to encrypt and the stringified mapping of the credential disclosures or the error code
+ * @param state - Optional state to include in the POST body
  * @returns A URL-encoded string suitable for an `application/x-www-form-urlencoded` POST body.
  */
 export const buildDirectPostBody = async (
-  requestObject: Out<VerifyRequestObject>["requestObject"],
-  payload: DirectAuthorizationBodyPayload
+  payload: DirectAuthorizationBodyPayload,
+  state?: string
 ): Promise<string> => {
   const formUrlEncodedBody = new URLSearchParams({
-    ...(requestObject.state && { state: requestObject.state }),
+    ...(state && { state: state }),
     ...Object.entries(payload).reduce(
       (acc, [key, value]) => ({
         ...acc,
@@ -193,10 +193,11 @@ export const sendLegacyAuthorizationResponse: SendLegacyAuthorizationResponse =
       descriptor_map,
     };
 
-    const requestBody = await buildDirectPostJwtBody(requestObject, rpConf, {
-      vp_token,
-      presentation_submission,
-    });
+    const requestBody = await buildDirectPostJwtBody(
+      { vp_token, presentation_submission },
+      rpConf,
+      requestObject.state
+    );
 
     // 3. Send the authorization response via HTTP POST and validate the response
     return await appFetch(requestObject.response_uri, {
@@ -232,15 +233,19 @@ export const sendAuthorizationResponse: SendAuthorizationResponse = async (
   { appFetch = fetch } = {}
 ): Promise<AuthorizationResponse> => {
   // 1. Prepare the VP token as a JSON object with keys corresponding to the DCQL query credential IDs
-  const requestBody = await buildDirectPostJwtBody(requestObject, rpConf, {
-    vp_token: remotePresentations.reduce(
-      (acc, presentation) => ({
-        ...acc,
-        [presentation.credentialId]: presentation.vpToken,
-      }),
-      {} as Record<string, string>
-    ),
-  });
+  const requestBody = await buildDirectPostJwtBody(
+    {
+      vp_token: remotePresentations.reduce(
+        (acc, presentation) => ({
+          ...acc,
+          [presentation.credentialId]: presentation.vpToken,
+        }),
+        {} as Record<string, string>
+      ),
+    },
+    rpConf,
+    requestObject.state
+  );
 
   // 2. Send the authorization response via HTTP POST and validate the response
   return await appFetch(requestObject.response_uri, {
@@ -261,8 +266,12 @@ export const sendAuthorizationResponse: SendAuthorizationResponse = async (
  * to the Relying Party, completing the presentation flow.
  */
 export type SendAuthorizationErrorResponse = (
-  requestObject: Out<VerifyRequestObject>["requestObject"],
-  error: { error: ErrorResponse; errorDescription: string },
+  params: {
+    responseUri: string;
+    error: ErrorResponse;
+    errorDescription: string;
+    state?: string;
+  },
   context?: {
     appFetch?: GlobalFetch["fetch"];
   }
@@ -272,23 +281,21 @@ export type SendAuthorizationErrorResponse = (
  * Sends the authorization error response to the Relying Party (RP) using the specified `response_mode`.
  * This function completes the presentation flow in an OpenID 4 Verifiable Presentations scenario.
  *
- * @param requestObject - The request details, including presentation requirements.
- * @param error - The response error value, with description
+ * @param params - The parameters needed to send the authorization error, including the error value and description.
  * @param context - Contains optional custom fetch implementation.
  * @returns Parsed and validated authorization response from the Relying Party.
  */
 export const sendAuthorizationErrorResponse: SendAuthorizationErrorResponse =
   async (
-    requestObject,
-    { error, errorDescription },
+    { responseUri, error, errorDescription, state },
     { appFetch = fetch } = {}
   ): Promise<AuthorizationResponse> => {
-    const requestBody = await buildDirectPostBody(requestObject, {
-      error,
-      error_description: errorDescription,
-    });
+    const requestBody = await buildDirectPostBody(
+      { error, error_description: errorDescription },
+      state
+    );
 
-    return await appFetch(requestObject.response_uri, {
+    return await appFetch(responseUri, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",

--- a/src/credential/presentation/08-send-authorization-response.ts
+++ b/src/credential/presentation/08-send-authorization-response.ts
@@ -273,8 +273,7 @@ export type SendAuthorizationErrorResponse = (
  * This function completes the presentation flow in an OpenID 4 Verifiable Presentations scenario.
  *
  * @param requestObject - The request details, including presentation requirements.
- * @param error - The response error value
- * @param jwkKeys - Array of JWKs from the Relying Party for optional encryption.
+ * @param error - The response error value, with description
  * @param context - Contains optional custom fetch implementation.
  * @returns Parsed and validated authorization response from the Relying Party.
  */

--- a/src/credential/presentation/08-send-authorization-response.ts
+++ b/src/credential/presentation/08-send-authorization-response.ts
@@ -8,7 +8,6 @@ import {
   type RemotePresentation,
   DirectAuthorizationBodyPayload,
   ErrorResponse,
-  AuthorizationResponseError,
   type LegacyRemotePresentation,
 } from "./types";
 import * as z from "zod";
@@ -313,24 +312,19 @@ const handleAuthorizationResponseError = (e: unknown) => {
     throw e;
   }
 
-  // Try to extract the message from the error. The original error is automatically passed in the `reason` field.
-  const error = AuthorizationResponseError.safeParse(e.reason);
-  const errorMessage = error.success
-    ? error.data.error_description
-    : "Unable to successfully send the Authorization Response";
-
   throw new ResponseErrorBuilder(RelyingPartyResponseError)
     .handle(400, {
       code: RelyingPartyResponseErrorCodes.InvalidAuthorizationResponse,
-      message: errorMessage,
+      message:
+        "The Authorization Response contains invalid parameters or it is malformed",
     })
     .handle(403, {
       code: RelyingPartyResponseErrorCodes.InvalidAuthorizationResponse,
-      message: errorMessage,
+      message: "The Authorization Response was forbidden",
     })
     .handle("*", {
       code: RelyingPartyResponseErrorCodes.RelyingPartyGenericError,
-      message: errorMessage,
+      message: "Unable to successfully send the Authorization Response",
     })
     .buildFrom(e);
 };

--- a/src/credential/presentation/README.md
+++ b/src/credential/presentation/README.md
@@ -26,10 +26,12 @@ sequenceDiagram
 
 | Error                       | Description|
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ValidationFailed`          | The presentation request is not valid, for instance the DCQL query is invalid.                                                                         |
+| `InvalidRequestObject`      | The Request Object is not valid, for instance it is malformed or its signature cannot be verified.                                                     |
+| `DcqlError`                 | The DCQL query cannot be evaluated because it contains errors.                                                                                         |
 | `CredentialsNotFoundError`  | The presentation cannot be completed because the Wallet does not contain all requested credentials. The missing credentials can be found in `details`. |
 | `RelyingPartyResponseError` | Error in the Relying Party's response. See the next table for more details.                                                                            |
 
+#### RelyingPartyResponseError
 The following HTTP errors are mapped to a `RelyingPartyResponseError` with specific codes.
 
 | HTTP Status  | Error Code                              | Description                                                                                                  |

--- a/src/credential/presentation/README.md
+++ b/src/credential/presentation/README.md
@@ -24,11 +24,11 @@ sequenceDiagram
 
 ## Mapped results
 
-|Error|Description|
-|-----|-----------|
-|`ValidationFailed`|The presentation request is not valid, for instance the DCQL query is invalid.|
-|`CredentialsNotFoundError`|The presentation cannot be completed because the Wallet does not contain all requested credentials. The missing credentials can be found in `details`.|
-
+| Error                       | Description|
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ValidationFailed`          | The presentation request is not valid, for instance the DCQL query is invalid.                                                                         |
+| `CredentialsNotFoundError`  | The presentation cannot be completed because the Wallet does not contain all requested credentials. The missing credentials can be found in `details`. |
+| `RelyingPartyResponseError` | Error in the Relying Party's response. See the next table for more details.                                                                            |
 
 The following HTTP errors are mapped to a `RelyingPartyResponseError` with specific codes.
 

--- a/src/credential/presentation/README.md
+++ b/src/credential/presentation/README.md
@@ -30,6 +30,14 @@ sequenceDiagram
 |`CredentialsNotFoundError`|The presentation cannot be completed because the Wallet does not contain all requested credentials. The missing credentials can be found in `details`.|
 
 
+The following HTTP errors are mapped to a `RelyingPartyResponseError` with specific codes.
+
+| HTTP Status  | Error Code                              | Description                                                                                                  |
+| ------------ | --------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `400`, `403` | `ERR_RP_INVALID_AUTHORIZATION_RESPONSE` | The Relying Party rejected the Authorization Response sent by the Wallet because it was deemed invalid.      |
+| `*`          | `ERR_RP_GENERIC_ERROR`                  | This is a generic error code to map unexpected errors that occurred when interacting with the Relying Party. |
+
+
 ## Examples
 
 <details>

--- a/src/credential/presentation/__tests__/05-verify-request-object.test.ts
+++ b/src/credential/presentation/__tests__/05-verify-request-object.test.ts
@@ -1,0 +1,137 @@
+import * as jwtModule from "@pagopa/io-react-native-jwt";
+import type { RelyingPartyEntityConfiguration } from "../../../trust";
+import { InvalidRequestObjectError } from "../errors";
+import type { RequestObject } from "../types";
+import { verifyRequestObject } from "..";
+
+const CLIENT_ID = "https://relying_party.rp";
+const VERIFY_RESULT_MOCK = { payload: {}, protectedHeader: {} };
+
+const requestObjectJwt =
+  "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImU0NmE0YmY4LWE4NGEtNDdkNi1iZjhlLWFiMGE0MGZmMmQ0YiJ9.eyJjbGllbnRfaWQiOiJodHRwczovL3JlbHlpbmdfcGFydHkucnAiLCJpc3MiOiJodHRwczovL3JlbHlpbmdfcGFydHkucnAiLCJyZXNwb25zZV9tb2RlIjoiZGlyZWN0X3Bvc3Quand0Iiwic3RhdGUiOiJhYmMiLCJyZXNwb25zZV90eXBlIjoidnBfdG9rZW4iLCJub25jZSI6IjEyMyIsInJlc3BvbnNlX3VyaSI6Imh0dHBzOi8vcmVseWluZ19wYXJ0eS5ycC9yZXNwb25zZV91cmkiLCJpYXQiOjE3NDU5MjM5MjMsImV4cCI6MTc2NTkzMzkyMywiZGNxbF9xdWVyeSI6e319.N7A1y1Xzdfu4OYUuCLjiasdKoKlzU3gKcG2uHYUoPFVD1VYZU2YxUKLDdllqTrCpK4z_uCT7g8foO6ra1YdBlmr89Vf50qXMBe9Db7H31SE3n90nGFNxxjXNtTJrb20k4HQ5w9ATn9_-rkdVpDPjsdIj8ao3HQ_MYsTU-z03b9rgeesodcDJfuIsBtvUTpHG0voWQC65ZK2HOIVt6NNLVgxKZyB6VJHFbC_0_5-uzOGtYsyQSva_Wj9LHiMiqLUrqJCE8FToUAEhZ2QK9npxiPsUQH0gE24rowUO156ezJD-jnxZrU2atvMaNtgJgLik4z9WlgaUugnjvdFMDOM2sw";
+
+const mockRp = {
+  openid_credential_verifier: {
+    jwks: {
+      keys: [
+        {
+          kid: "e46a4bf8-a84a-47d6-bf8e-ab0a40ff2d4b",
+          kty: "RSA",
+          n: "ngbUsmZnMmNw-A1YzhiHOTJiFijHvH38xUamRrcbYKk3TCepRE1JL3cXNoLOBvxGy5pPLT6qo8n_Rw3TmcTaxxXsW1GSmCf90P_pj36kyOffILFNG8bqYt6LO2O74RAJIKy7szDrLZGg5iRjKlKwDjmzn3CfBM4pbam_Gzlj3YZ42DoKHZqRROe7kUVlPU0ro8rtLnBhp8Qotd8CbtVn4tRtfIR4FJBgz_isAhVvJ9rL-2dEQmqiOd-Wk2kpY_3BJd3LVqIi8BTx6EysgZoba1DyWpCDg_0UFjaqh8iWayB0IJQbtIv2mX5Pa0bLjWjW2wuDlqkh4xp1_4fyn1wt7w",
+          e: "AQAB",
+          alg: "RS256",
+          use: "sig",
+        },
+      ],
+    },
+  },
+} as RelyingPartyEntityConfiguration["payload"]["metadata"];
+
+describe("verifyRequestObject", () => {
+  it("should throw InvalidRequestObjectError when no public key was found in the EC", async () => {
+    await expect(() =>
+      verifyRequestObject(requestObjectJwt, {
+        rpConf: {
+          openid_credential_verifier: {
+            jwks: {
+              keys: [{ kid: "no_key" }],
+            },
+          },
+        } as RelyingPartyEntityConfiguration["payload"]["metadata"],
+        rpSubject: CLIENT_ID,
+        clientId: CLIENT_ID,
+      })
+    ).rejects.toThrow(
+      new InvalidRequestObjectError(
+        "The public key for signature verification (e46a4bf8-a84a-47d6-bf8e-ab0a40ff2d4b) cannot be found in the Entity Configuration"
+      )
+    );
+  });
+
+  it("should throw InvalidRequestObjectError when the JWT signature is invalid", async () => {
+    jest.spyOn(jwtModule, "verify").mockRejectedValue("Invalid signature");
+
+    await expect(() =>
+      verifyRequestObject(requestObjectJwt, {
+        rpConf: mockRp,
+        rpSubject: CLIENT_ID,
+        clientId: CLIENT_ID,
+      })
+    ).rejects.toThrow(
+      new InvalidRequestObjectError(
+        "The Request Object signature verification failed"
+      )
+    );
+  });
+
+  it("should throw InvalidRequestObjectError when the Request Object shape is invalid", async () => {
+    jest.spyOn(jwtModule, "verify").mockResolvedValue(VERIFY_RESULT_MOCK);
+    const jwt =
+      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImU0NmE0YmY4LWE4NGEtNDdkNi1iZjhlLWFiMGE0MGZmMmQ0YiJ9.eyJjbGllbnRfaWQiOiJodHRwczovL3JlbHlpbmdfcGFydHkucnAiLCJpc3MiOiJodHRwczovL3JlbHlpbmdfcGFydHkucnAiLCJyZXNwb25zZV9tb2RlIjoiZGlyZWN0X3Bvc3Quand0Iiwic3RhdGUiOiJhYmMiLCJyZXNwb25zZV90eXBlIjoiaW52YWxpZF92cF90b2tlbiIsIm5vbmNlIjoiMTIzIiwicmVzcG9uc2VfdXJpIjoiaHR0cHM6Ly9yZWx5aW5nX3BhcnR5LnJwL3Jlc3BvbnNlX3VyaSIsImlhdCI6MTc0NTkyMzkyMywiZXhwIjoxNzY1OTMzOTIzLCJkY3FsX3F1ZXJ5Ijp7fX0.QH5KojcaROg8bPCcazbM-lrlcpRVe1CcuKFALYU2Hzk_Vdm-Jeue2XSQNnvZxwok-w8Ou5ihQ3bBkR7hziSN_P81jPJPyiXBMgPbAHWwECGEcyVrtxefT37-6JOFvhBVyyltWEEkhWn9xroYtu6ZjbfUvher-r9lsGtfGJXHNhDMxNuYRjT_Jg5c7JjCZCdNqAsZOVf8p98r6fPh0uQVIm6ay-F-Akp_dxmD33BcfMN_yB00w0aUB6VrrgRVlPhyvjxhdvyRfB__1hV1wGzrt0XTHtuCgqYzi7CoIdPk6PcRPtxV_SMYUX6swjNiIRY9_nD7c5AHKMz1QpTrZkHGog";
+    await expect(() =>
+      verifyRequestObject(jwt, {
+        rpConf: mockRp,
+        rpSubject: CLIENT_ID,
+        clientId: CLIENT_ID,
+      })
+    ).rejects.toThrow(
+      new InvalidRequestObjectError(
+        "The Request Object cannot be parsed successfully"
+      )
+    );
+  });
+
+  it("should throw InvalidRequestObjectError when the client ID does not match", async () => {
+    jest.spyOn(jwtModule, "verify").mockResolvedValue(VERIFY_RESULT_MOCK);
+    await expect(() =>
+      verifyRequestObject(requestObjectJwt, {
+        rpConf: mockRp,
+        rpSubject: CLIENT_ID,
+        clientId: "wrong_client_id",
+      })
+    ).rejects.toThrow(
+      new InvalidRequestObjectError(
+        "Client ID does not match Request Object or Entity Configuration"
+      )
+    );
+  });
+
+  it("should throw InvalidRequestObjectError when the state does not match", async () => {
+    jest.spyOn(jwtModule, "verify").mockResolvedValue(VERIFY_RESULT_MOCK);
+    await expect(() =>
+      verifyRequestObject(requestObjectJwt, {
+        rpConf: mockRp,
+        rpSubject: CLIENT_ID,
+        clientId: CLIENT_ID,
+        state: "xyz",
+      })
+    ).rejects.toThrow(
+      new InvalidRequestObjectError(
+        "The provided state does not match the Request Object's"
+      )
+    );
+  });
+
+  it("should successfully verify the Request Object", async () => {
+    jest.spyOn(jwtModule, "verify").mockResolvedValue(VERIFY_RESULT_MOCK);
+    const expected: RequestObject = {
+      client_id: CLIENT_ID,
+      iss: CLIENT_ID,
+      response_mode: "direct_post.jwt",
+      state: "abc",
+      response_type: "vp_token",
+      nonce: "123",
+      response_uri: "https://relying_party.rp/response_uri",
+      iat: 1745923923,
+      exp: 1765933923,
+      dcql_query: {},
+    };
+    expect(
+      await verifyRequestObject(requestObjectJwt, {
+        rpConf: mockRp,
+        rpSubject: CLIENT_ID,
+        clientId: CLIENT_ID,
+      })
+    ).toEqual({ requestObject: expected });
+  });
+});

--- a/src/credential/presentation/__tests__/07-evaluate-dcql-query.test.ts
+++ b/src/credential/presentation/__tests__/07-evaluate-dcql-query.test.ts
@@ -1,4 +1,4 @@
-import type { DcqlQuery } from "dcql";
+import { DcqlError, type DcqlQuery } from "dcql";
 import { evaluateDcqlQuery } from "../07-evaluate-dcql-query";
 import { CredentialsNotFoundError, type NotFoundDetail } from "../errors";
 
@@ -27,7 +27,7 @@ describe("evaluateDcqlQuery", () => {
       ],
     };
 
-    expect(() => evaluateDcqlQuery(credentials, query)).toThrowError();
+    expect(() => evaluateDcqlQuery(credentials, query)).toThrowError(DcqlError);
   });
 
   it("should throw error when the DCQL is invalid", () => {
@@ -42,7 +42,7 @@ describe("evaluateDcqlQuery", () => {
       ],
     };
 
-    expect(() => evaluateDcqlQuery(credentials, query)).toThrowError();
+    expect(() => evaluateDcqlQuery(credentials, query)).toThrowError(DcqlError);
   });
 
   test.each([

--- a/src/credential/presentation/__tests__/08-send-authorization-response.test.ts
+++ b/src/credential/presentation/__tests__/08-send-authorization-response.test.ts
@@ -67,9 +67,10 @@ describe("buildDirectPostBody", () => {
   it("should build the correct formBody string", async () => {
     const mockVpToken = "mock_vp_token";
 
-    const result = await buildDirectPostBody(mockRequestObject, {
-      vp_token: { PID: mockVpToken },
-    });
+    const result = await buildDirectPostBody(
+      { vp_token: { PID: mockVpToken } },
+      mockRequestObject.state
+    );
 
     // URLSearchParams output should be 'state=mock_state&vp_token={"PID":"mock_vp_token"}'
     expect(result).toContain("state=mock_state");
@@ -82,9 +83,11 @@ describe("buildDirectPostJwtBody", () => {
   it("should build the correct formBody string", async () => {
     const mockVpToken = "mock_vp_token";
 
-    const result = await buildDirectPostJwtBody(mockRequestObject, mockRpConf, {
-      vp_token: { PID: mockVpToken },
-    });
+    const result = await buildDirectPostJwtBody(
+      { vp_token: { PID: mockVpToken } },
+      mockRpConf,
+      mockRequestObject.state
+    );
 
     expect(result).toBe("response=mock_encrypted_jwe&state=mock_state");
   });
@@ -164,8 +167,9 @@ describe("sendAuthorizationErrorResponse", () => {
     });
 
     const res = await sendAuthorizationErrorResponse(
-      mockRequestObject,
       {
+        responseUri: mockRequestObject.response_uri,
+        state: mockRequestObject.state,
         error: "access_denied",
         errorDescription: "an_error_occurred",
       },

--- a/src/credential/presentation/__tests__/08-send-authorization-response.test.ts
+++ b/src/credential/presentation/__tests__/08-send-authorization-response.test.ts
@@ -86,7 +86,6 @@ describe("buildDirectPostJwtBody", () => {
       vp_token: { PID: mockVpToken },
     });
 
-    // Should call chooseRSAPublicKeyToEncrypt and produce a "response=mock_encrypted_jwe"
     expect(result).toBe("response=mock_encrypted_jwe&state=mock_state");
   });
 });

--- a/src/credential/presentation/__tests__/08-send-authorization-response.test.ts
+++ b/src/credential/presentation/__tests__/08-send-authorization-response.test.ts
@@ -1,0 +1,184 @@
+import {
+  RelyingPartyResponseError,
+  RelyingPartyResponseErrorCodes,
+} from "../../../utils/errors";
+import type { RelyingPartyEntityConfiguration } from "../../../trust";
+import {
+  buildDirectPostBody,
+  buildDirectPostJwtBody,
+  sendAuthorizationResponse,
+  sendAuthorizationErrorResponse,
+} from "../08-send-authorization-response";
+import type { RemotePresentation, RequestObject } from "../types";
+
+jest.mock("@pagopa/io-react-native-jwt", () => {
+  const actualModule = jest.requireActual("@pagopa/io-react-native-jwt");
+  return {
+    ...actualModule,
+    EncryptJwe: jest.fn().mockImplementation(() => ({
+      encrypt: jest.fn().mockResolvedValue("mock_encrypted_jwe"),
+    })),
+    SignJWT: jest.fn().mockImplementation(() => ({
+      setProtectedHeader: jest.fn().mockReturnThis(),
+      setPayload: jest.fn().mockReturnThis(),
+      setAudience: jest.fn().mockReturnThis(),
+      setIssuedAt: jest.fn().mockReturnThis(),
+      setExpirationTime: jest.fn().mockReturnThis(),
+      sign: jest.fn().mockResolvedValue("mock_signed_kbjwt"),
+    })),
+    sha256ToBase64: jest.fn().mockResolvedValue("mock_encrypted_jwe"),
+  };
+});
+
+const mockRequestObject: RequestObject = {
+  iat: 1234567890,
+  exp: 1234567899,
+  iss: "https://mock.rp",
+  client_id: "mock_client_id",
+  response_type: "vp_token",
+  nonce: "mock_nonce",
+  response_uri: "https://mock.rp/response",
+  scope: "mock_scope",
+  state: "mock_state",
+  response_mode: "direct_post.jwt",
+  dcql_query: {
+    credentials: [
+      {
+        id: "PID",
+        format: "vc+sd-jwt",
+        meta: { vct_values: ["PersonIdentificationData"] },
+      },
+    ],
+  },
+};
+
+const mockRpConf = {
+  openid_credential_verifier: {
+    jwks: {
+      keys: [
+        { kid: "rsa-key-1", use: "enc", kty: "RSA" },
+        { kid: "something-else", use: "sig", kty: "EC" },
+      ],
+    },
+  },
+} as RelyingPartyEntityConfiguration["payload"]["metadata"];
+
+describe("buildDirectPostBody", () => {
+  it("should build the correct formBody string", async () => {
+    const mockVpToken = "mock_vp_token";
+
+    const result = await buildDirectPostBody(mockRequestObject, {
+      vp_token: { PID: mockVpToken },
+    });
+
+    // URLSearchParams output should be 'state=mock_state&vp_token={"PID":"mock_vp_token"}'
+    expect(result).toContain("state=mock_state");
+    // Because JSON.stringify is used, check approximate structure:
+    expect(result).toContain("vp_token=%7B%22PID%22%3A%22mock_vp_token%22%7D");
+  });
+});
+
+describe("buildDirectPostJwtBody", () => {
+  it("should build the correct formBody string", async () => {
+    const mockVpToken = "mock_vp_token";
+
+    const result = await buildDirectPostJwtBody(mockRequestObject, mockRpConf, {
+      vp_token: { PID: mockVpToken },
+    });
+
+    // Should call chooseRSAPublicKeyToEncrypt and produce a "response=mock_encrypted_jwe"
+    expect(result).toBe("response=mock_encrypted_jwe&state=mock_state");
+  });
+});
+
+describe("sendAuthorizationResponse", () => {
+  const mockFetch = jest.fn();
+  const remotePresentations: RemotePresentation[] = [
+    {
+      requestedClaims: ["name", "surname"],
+      credentialId: "PID",
+      format: "dc+sd-jwt",
+      vpToken: "mock_vp_token",
+    },
+  ];
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("should use buildDirectPostJwtBody when response_mode is direct_post.jwt", async () => {
+    mockFetch.mockResolvedValue({
+      headers: new Headers({ "content-type": "application/json" }),
+      status: 200,
+      json: () => Promise.resolve({ status: "ok", response_code: "200" }),
+    });
+
+    await sendAuthorizationResponse(
+      mockRequestObject,
+      remotePresentations,
+      mockRpConf,
+      { appFetch: mockFetch }
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("https://mock.rp/response", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "response=mock_encrypted_jwe&state=mock_state",
+    });
+  });
+
+  test.each([
+    [RelyingPartyResponseErrorCodes.InvalidAuthorizationResponse, 400],
+    [RelyingPartyResponseErrorCodes.InvalidAuthorizationResponse, 403],
+    [RelyingPartyResponseErrorCodes.RelyingPartyGenericError, 500],
+  ])(
+    "should throw RelyingPartyResponseError with code %s when the HTTP status is %s",
+    async (errorCode, status) => {
+      mockFetch.mockResolvedValue({
+        headers: new Headers({ "content-type": "application/json" }),
+        status,
+        json: () => Promise.resolve(""),
+      });
+
+      try {
+        await sendAuthorizationResponse(
+          mockRequestObject,
+          remotePresentations,
+          mockRpConf,
+          { appFetch: mockFetch }
+        );
+      } catch (error) {
+        expect(error).toBeInstanceOf(RelyingPartyResponseError);
+        expect((error as RelyingPartyResponseError).code).toEqual(errorCode);
+      }
+    }
+  );
+});
+
+describe("sendAuthorizationErrorResponse", () => {
+  it("should send an error code building the body using buildDirectPostBody", async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      headers: new Headers({ "content-type": "application/json" }),
+      status: 200,
+      json: () => Promise.resolve({ status: "ok", response_code: "200" }),
+    });
+
+    const res = await sendAuthorizationErrorResponse(
+      mockRequestObject,
+      {
+        error: "access_denied",
+        errorDescription: "an_error_occurred",
+      },
+      { appFetch: mockFetch }
+    );
+
+    expect(res).toEqual({ status: "ok", response_code: "200" });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("https://mock.rp/response", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "state=mock_state&error=access_denied&error_description=an_error_occurred",
+    });
+  });
+});

--- a/src/credential/presentation/__tests__/08-send-authorization-response.test.ts
+++ b/src/credential/presentation/__tests__/08-send-authorization-response.test.ts
@@ -67,10 +67,9 @@ describe("buildDirectPostBody", () => {
   it("should build the correct formBody string", async () => {
     const mockVpToken = "mock_vp_token";
 
-    const result = await buildDirectPostBody(
-      { vp_token: { PID: mockVpToken } },
-      mockRequestObject.state
-    );
+    const result = await buildDirectPostBody(mockRequestObject, {
+      vp_token: { PID: mockVpToken },
+    });
 
     // URLSearchParams output should be 'state=mock_state&vp_token={"PID":"mock_vp_token"}'
     expect(result).toContain("state=mock_state");
@@ -83,11 +82,9 @@ describe("buildDirectPostJwtBody", () => {
   it("should build the correct formBody string", async () => {
     const mockVpToken = "mock_vp_token";
 
-    const result = await buildDirectPostJwtBody(
-      { vp_token: { PID: mockVpToken } },
-      mockRpConf,
-      mockRequestObject.state
-    );
+    const result = await buildDirectPostJwtBody(mockRequestObject, mockRpConf, {
+      vp_token: { PID: mockVpToken },
+    });
 
     expect(result).toBe("response=mock_encrypted_jwe&state=mock_state");
   });
@@ -167,9 +164,8 @@ describe("sendAuthorizationErrorResponse", () => {
     });
 
     const res = await sendAuthorizationErrorResponse(
+      mockRequestObject,
       {
-        responseUri: mockRequestObject.response_uri,
-        state: mockRequestObject.state,
         error: "access_denied",
         errorDescription: "an_error_occurred",
       },

--- a/src/credential/presentation/errors.ts
+++ b/src/credential/presentation/errors.ts
@@ -1,4 +1,5 @@
 import { IoWalletError, serializeAttrs } from "../../utils/errors";
+export { DcqlError } from "dcql";
 
 /**
  * An error subclass thrown when auth request decode fail
@@ -57,18 +58,17 @@ export class InvalidQRCodeError extends IoWalletError {
 }
 
 /**
- * When the entity is unverified because the Relying Party is not trusted.
- *
+ * When the Request Object sent by the Relying Party is not valid
  */
-export class UnverifiedEntityError extends IoWalletError {
-  code = "ERR_UNVERIFIED_RP_ENTITY";
+export class InvalidRequestObjectError extends IoWalletError {
+  code = "ERR_INVALID_REQUEST_OBJECT";
 
-  /**
-   * @param reason A description of why the entity cannot be verified.
-   */
-  constructor(reason: string) {
-    const message = `Unverified entity: ${reason}.`;
+  /** Detailed reason for the Request Object validation failure. */
+  reason: string;
+
+  constructor(message: string, reason = "unspecified") {
     super(message);
+    this.reason = reason;
   }
 }
 

--- a/src/credential/presentation/index.ts
+++ b/src/credential/presentation/index.ts
@@ -33,6 +33,8 @@ import {
   type SendAuthorizationResponse,
   sendLegacyAuthorizationResponse,
   type SendLegacyAuthorizationResponse,
+  sendAuthorizationErrorResponse,
+  type SendAuthorizationErrorResponse,
 } from "./08-send-authorization-response";
 import * as Errors from "./errors";
 
@@ -49,6 +51,7 @@ export {
   prepareRemotePresentations,
   sendAuthorizationResponse,
   sendLegacyAuthorizationResponse,
+  sendAuthorizationErrorResponse,
   Errors,
 };
 export type {
@@ -64,4 +67,5 @@ export type {
   PrepareRemotePresentations,
   SendAuthorizationResponse,
   SendLegacyAuthorizationResponse,
+  SendAuthorizationErrorResponse,
 };

--- a/src/credential/presentation/types.ts
+++ b/src/credential/presentation/types.ts
@@ -168,14 +168,3 @@ export const DirectAuthorizationBodyPayload = z.union([
   z.object({ error: ErrorResponse, error_description: z.string() }),
   LegacyDirectAuthorizationBodyPayload,
 ]);
-
-/**
- * The error object sent by the Relying Party when it is unable to process the Authorization Response.
- */
-export type AuthorizationResponseError = z.infer<
-  typeof AuthorizationResponseError
->;
-export const AuthorizationResponseError = z.object({
-  error: z.string(),
-  error_description: z.string(),
-});

--- a/src/credential/presentation/types.ts
+++ b/src/credential/presentation/types.ts
@@ -133,26 +133,37 @@ export const RequestObjectWalletCapabilities = z.object({
 });
 
 /**
- * Authorization Response payload when using `presentation_definition`.
- * @deprecated Use `DirectAuthorizationBodyPayload`
+ * This type models the possible error responses the OpenID4VP protocol allows for a presentation of a credential.
+ * See https://italia.github.io/eid-wallet-it-docs/versione-corrente/en/pid-eaa-presentation.html#authorization-response-errors for more information.
  */
-export type LegacyDirectAuthorizationBodyPayload = z.infer<
-  typeof LegacyDirectAuthorizationBodyPayload
->;
+export type ErrorResponse = z.infer<typeof ErrorResponse>;
+export const ErrorResponse = z.enum([
+  "invalid_request_object",
+  "invalid_request_uri",
+  "vp_formats_not_supported",
+  "invalid_request",
+  "access_denied",
+  "invalid_client",
+]);
+
 /**
  * @deprecated Use `DirectAuthorizationBodyPayload`
  */
-export const LegacyDirectAuthorizationBodyPayload = z.object({
+const LegacyDirectAuthorizationBodyPayload = z.object({
   vp_token: z.union([z.string(), z.array(z.string())]).optional(),
   presentation_submission: z.record(z.string(), z.unknown()),
 });
 
 /**
- * Authorization Response payload when using DCQL queries.
+ * Authorization Response payload sent to the Relying Party.
  */
 export type DirectAuthorizationBodyPayload = z.infer<
   typeof DirectAuthorizationBodyPayload
 >;
-export const DirectAuthorizationBodyPayload = z.object({
-  vp_token: z.record(z.string(), z.string()),
-});
+export const DirectAuthorizationBodyPayload = z.union([
+  z.object({
+    vp_token: z.record(z.string(), z.string()),
+  }),
+  z.object({ error: ErrorResponse }),
+  LegacyDirectAuthorizationBodyPayload,
+]);

--- a/src/credential/presentation/types.ts
+++ b/src/credential/presentation/types.ts
@@ -134,6 +134,7 @@ export const RequestObjectWalletCapabilities = z.object({
 
 /**
  * This type models the possible error responses the OpenID4VP protocol allows for a presentation of a credential.
+ * When the Wallet encounters one of these errors, it will notify the Relying Party through the `response_uri` endpoint.
  * See https://italia.github.io/eid-wallet-it-docs/versione-corrente/en/pid-eaa-presentation.html#authorization-response-errors for more information.
  */
 export type ErrorResponse = z.infer<typeof ErrorResponse>;
@@ -167,3 +168,14 @@ export const DirectAuthorizationBodyPayload = z.union([
   z.object({ error: ErrorResponse, error_description: z.string() }),
   LegacyDirectAuthorizationBodyPayload,
 ]);
+
+/**
+ * The error object sent by the Relying Party when it is unable to process the Authorization Response.
+ */
+export type AuthorizationResponseError = z.infer<
+  typeof AuthorizationResponseError
+>;
+export const AuthorizationResponseError = z.object({
+  error: z.string(),
+  error_description: z.string(),
+});

--- a/src/credential/presentation/types.ts
+++ b/src/credential/presentation/types.ts
@@ -164,6 +164,6 @@ export const DirectAuthorizationBodyPayload = z.union([
   z.object({
     vp_token: z.record(z.string(), z.string()),
   }),
-  z.object({ error: ErrorResponse }),
+  z.object({ error: ErrorResponse, error_description: z.string() }),
   LegacyDirectAuthorizationBodyPayload,
 ]);

--- a/src/utils/error-codes.ts
+++ b/src/utils/error-codes.ts
@@ -43,8 +43,19 @@ export const WalletProviderResponseErrorCodes = {
   WalletInstanceNotFound: "ERR_IO_WALLET_INSTANCE_NOT_FOUND",
 } as const;
 
+export const RelyingPartyResponseErrorCodes = {
+  RelyingPartyGenericError: "ERR_RP_GENERIC_ERROR",
+  /**
+   * An error code thrown then the Relying Party rejects the Wallet's Authorization Response.
+   */
+  InvalidAuthorizationResponse: "ERR_RP_INVALID_AUTHORIZATION_RESPONSE",
+} as const;
+
 export type IssuerResponseErrorCode =
   (typeof IssuerResponseErrorCodes)[keyof typeof IssuerResponseErrorCodes];
 
 export type WalletProviderResponseErrorCode =
   (typeof WalletProviderResponseErrorCodes)[keyof typeof WalletProviderResponseErrorCodes];
+
+export type RelyingPartyResponseErrorCode =
+  (typeof RelyingPartyResponseErrorCodes)[keyof typeof RelyingPartyResponseErrorCodes];

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -137,7 +137,7 @@ export class IssuerResponseError extends UnexpectedStatusCodeError {
  */
 export class WalletProviderResponseError extends UnexpectedStatusCodeError {
   code: WalletProviderResponseErrorCode;
-  reason: GenericErrorReason;
+  reason: ProblemDetail;
 
   constructor(params: {
     code?: WalletProviderResponseErrorCode;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -229,9 +229,9 @@ export function extractErrorMessageFromIssuerConf(
  * @returns A type guard that checks if the error is an instance of the given class and has the expected code
  */
 const makeErrorTypeGuard =
-  <T extends typeof UnexpectedStatusCodeError>(errorClass: T) =>
-  (error: unknown, code?: ExtractErrorCode<T>): error is T =>
-    error instanceof errorClass && error.code === (code ?? error.code);
+  <T extends typeof UnexpectedStatusCodeError>(ErrorClass: T) =>
+  (error: unknown, code?: ExtractErrorCode<T>): error is InstanceType<T> =>
+    error instanceof ErrorClass && error.code === (code ?? error.code);
 
 export const isIssuerResponseError = makeErrorTypeGuard(IssuerResponseError);
 export const isWalletProviderResponseError = makeErrorTypeGuard(

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -3,11 +3,17 @@ import type { CredentialIssuerEntityConfiguration } from "../trust";
 import {
   IssuerResponseErrorCodes,
   WalletProviderResponseErrorCodes,
+  RelyingPartyResponseErrorCodes,
   type IssuerResponseErrorCode,
   type WalletProviderResponseErrorCode,
+  type RelyingPartyResponseErrorCode,
 } from "./error-codes";
 
-export { IssuerResponseErrorCodes, WalletProviderResponseErrorCodes };
+export {
+  IssuerResponseErrorCodes,
+  WalletProviderResponseErrorCodes,
+  RelyingPartyResponseErrorCodes,
+};
 
 // An error reason that supports both a string and a generic JSON object
 type GenericErrorReason = string | Record<string, unknown>;
@@ -110,8 +116,6 @@ export class UnexpectedStatusCodeError extends IoWalletError {
 /**
  * An error subclass thrown when an Issuer HTTP request fails.
  * The specific error can be found in the `code` property.
- *
- * The class is generic over the error code to narrow down the reason.
  */
 export class IssuerResponseError extends UnexpectedStatusCodeError {
   code: IssuerResponseErrorCode;
@@ -133,7 +137,7 @@ export class IssuerResponseError extends UnexpectedStatusCodeError {
  */
 export class WalletProviderResponseError extends UnexpectedStatusCodeError {
   code: WalletProviderResponseErrorCode;
-  reason: ProblemDetail;
+  reason: GenericErrorReason;
 
   constructor(params: {
     code?: WalletProviderResponseErrorCode;
@@ -146,6 +150,25 @@ export class WalletProviderResponseError extends UnexpectedStatusCodeError {
     this.code =
       params.code ??
       WalletProviderResponseErrorCodes.WalletProviderGenericError;
+  }
+}
+
+/**
+ * An error subclass thrown when a Relying Party HTTP request fails.
+ * The specific error can be found in the `code` property.
+ */
+export class RelyingPartyResponseError extends UnexpectedStatusCodeError {
+  code: RelyingPartyResponseErrorCode;
+
+  constructor(params: {
+    code?: RelyingPartyResponseErrorCode;
+    message: string;
+    reason: GenericErrorReason;
+    statusCode: number;
+  }) {
+    super(params);
+    this.code =
+      params.code ?? RelyingPartyResponseErrorCodes.RelyingPartyGenericError;
   }
 }
 
@@ -200,36 +223,43 @@ export function extractErrorMessageFromIssuerConf(
 }
 
 /**
- * Type guard for issuer errors.
- * @param error The error to check
- * @param code Optional code to narrow down the issuer error
+ * Factory function to create a type guard for specific error classes.
+ *
+ * @param errorClass The error class to create the type guard for
+ * @returns A type guard that checks if the error is an instance of the given class and has the expected code
  */
-export const isIssuerResponseError = (
-  error: unknown,
-  code?: IssuerResponseErrorCode
-): error is IssuerResponseError =>
-  error instanceof IssuerResponseError && error.code === (code ?? error.code);
+const makeErrorTypeGuard =
+  <T extends typeof UnexpectedStatusCodeError>(errorClass: T) =>
+  (error: unknown, code?: ExtractErrorCode<T>): error is T =>
+    error instanceof errorClass && error.code === (code ?? error.code);
 
-/**
- * Type guard for wallet provider errors.
- * @param error The error to check
- * @param code Optional code to narrow down the wallet provider error
- */
-export const isWalletProviderResponseError = (
-  error: unknown,
-  code?: WalletProviderResponseErrorCode
-): error is WalletProviderResponseError =>
-  error instanceof WalletProviderResponseError &&
-  error.code === (code ?? error.code);
+export const isIssuerResponseError = makeErrorTypeGuard(IssuerResponseError);
+export const isWalletProviderResponseError = makeErrorTypeGuard(
+  WalletProviderResponseError
+);
+export const isRelyingPartyResponseError = makeErrorTypeGuard(
+  RelyingPartyResponseError
+);
 
-type ErrorCodeMap<T> = T extends typeof IssuerResponseError
-  ? IssuerResponseErrorCode
-  : T extends typeof WalletProviderResponseError
-    ? WalletProviderResponseErrorCode
-    : never;
+// Mapping type between error classes and their allowed codes
+type ErrorCodeMap =
+  | {
+      type: typeof IssuerResponseError;
+      code: IssuerResponseErrorCode;
+    }
+  | {
+      type: typeof WalletProviderResponseError;
+      code: WalletProviderResponseErrorCode;
+    }
+  | {
+      type: typeof RelyingPartyResponseError;
+      code: RelyingPartyResponseErrorCode;
+    };
+
+type ExtractErrorCode<T> = Extract<ErrorCodeMap, { type: T }>["code"];
 
 type ErrorCase<T> = {
-  code: ErrorCodeMap<T>;
+  code: ExtractErrorCode<T>;
   message: string;
   reason?: GenericErrorReason;
 };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added `sendAuthorizationErrorResponse` function to notify the RP
- Created `RelyingPartyResponseError` class with RP-specific error codes
- Explicitly handled 400 and 403 HTTP status code when sending the Authorization Response
- Thrown `InvalidRequestObjectError` in `verifyRequestObject` for validation-related errors
- Thrown `DcqlError` in `evaluateDcqlQuery` to unify DCQL-related errors
- Refactored some error related utils and types
- Updated the example app
- Added more tests

#### Motivation and Context

This PR improves the error handling in the presentation flow, by providing a specific `RelyingPartyResponseError` and a function to notify the Relying Party of any errors occurred when processing the Authorization Request.

#### How Has This Been Tested?

Tested against the test Relying Party instance, using the example app and a proxy to simulate 400, 403 and 500 HTTP status codes, with the following body:

```json
{
    "error": "invalid_request",
    "error_description": "An error occurred"
}
```

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
