### PR TITLE
fix: [WLEO-351,WLEO-352] Logging strings and remote server setting

### DIFF
--- a/example/src/navigator/MainStackNavigator.tsx
+++ b/example/src/navigator/MainStackNavigator.tsx
@@ -26,7 +26,7 @@ import type { SupportedCredentialsWithoutPid } from "../store/types";
 import { useAppDispatch, useAppSelector } from "../store/utils";
 import { labelByCredentialType } from "../utils/ui";
 import IdpSelectionScreen from "../screens/login/IdpSelectionScreen";
-import { selectEnv } from "../store/reducers/environment";
+import { selectLoggingAddress } from "../store/reducers/environment";
 import { initLogging } from "../utils/logging";
 import { PresentationScreen } from "../screens/PresentationScreen";
 import {
@@ -71,15 +71,15 @@ const lightTheme: Theme = {
 
 export const MainStackNavigator = () => {
   const ioAuthToken = useSelector(selectIoAuthToken);
-  const selectedEnv = useAppSelector(selectEnv);
+  const loggingServerAddr = useAppSelector(selectLoggingAddress);
   const dispatch = useAppDispatch();
 
   /**
    * Sets the logging environment when the selected environment changes.
    */
   useEffect(() => {
-    initLogging(selectedEnv);
-  }, [selectedEnv]);
+    initLogging(loggingServerAddr);
+  }, [loggingServerAddr]);
 
   const headerRight = useCallback(
     () => (

--- a/example/src/utils/environment.ts
+++ b/example/src/utils/environment.ts
@@ -80,12 +80,15 @@ export const SPID_DEMO_IDPHINT = "https://demo.spid.gov.it";
 export const getCieIdpHint = (env: EnvType) =>
   env === "pre" ? CIE_UAT_IDPHINT : CIE_PROD_IDPHINT;
 
+/**
+ * Validates a logging server address.
+ * It matches, for example, the following address:
+ * - http://example.com:8080/path/to/resource
+ * - https://192.168.1.1:5000/path/to/resource
+ * - http://localhost:8080
+ * - http://192.168.1.1:5000
+ * @param address - The address of the logging server.
+ * @returns the address if it is valid.
+ */
 export const validateLoggingAddress = (address: string) =>
-  z
-    .string()
-    .regex(
-      new RegExp(
-        "^((https?:\\/\\/)|(www.))(?:([a-zA-Z]+)|(\\d+\\.\\d+\\.\\d+\\.\\d+)):\\d{4}\\/\\S*$"
-      )
-    )
-    .parse(address);
+  z.string().url().parse(address);

--- a/example/src/utils/logging.ts
+++ b/example/src/utils/logging.ts
@@ -5,17 +5,8 @@ import {
   type transportFunctionType,
 } from "react-native-logs";
 
-/**
- * An implementation example of the logging system.
- * It creates a logger via `react-native-logs` and sends the logs to a custom server and to the console.
- * @param address - The address of the logging server.
- */
-export const initLogging = (address: string) => {
-  /**
-   * Initialize the logger with `react-native-logs`.
-   */
+const getRemoteServerTransport = (address: string) => {
   const customTransport: transportFunctionType<{}> = async (props) => {
-    console.log(address);
     await fetch(address, {
       method: "POST",
       headers: {
@@ -27,6 +18,22 @@ export const initLogging = (address: string) => {
       console.log(e);
     });
   };
+  return customTransport;
+};
+
+/**
+ * An implementation example of the logging system.
+ * It creates a logger via `react-native-logs` and sends the logs to a custom server and to the console.
+ * @param address - The address of the logging server.
+ */
+export const initLogging = (address?: string) => {
+  /**
+   * Initialize the logger with `react-native-logs`.
+   */
+
+  const transport = address
+    ? [consoleTransport, getRemoteServerTransport(address)]
+    : [consoleTransport];
 
   const reactNativeLogger = logger.createLogger({
     levels: {
@@ -36,7 +43,7 @@ export const initLogging = (address: string) => {
       error: 3,
     },
     severity: "debug",
-    transport: [consoleTransport, customTransport],
+    transport,
     transportOptions: {
       colors: {
         info: "blueBright",

--- a/src/credential/issuance/06-obtain-credential.ts
+++ b/src/credential/issuance/06-obtain-credential.ts
@@ -175,6 +175,11 @@ export const obtainCredential: ObtainCredential = async (
     });
   }
 
+  Logger.log(
+    LogLevel.DEBUG,
+    `Credential Response: ${JSON.stringify(credentialRes.data)}`
+  );
+
   return credentialRes.data;
 };
 

--- a/src/credential/issuance/07-verify-and-parse-credential.ts
+++ b/src/credential/issuance/07-verify-and-parse-credential.ts
@@ -222,7 +222,7 @@ const verifyAndParseCredentialSdJwt: WithFormat<"vc+sd-jwt"> = async (
     credentialCryptoContext
   );
 
-  Logger.log(LogLevel.DEBUG, `Decoded credential ${decoded}`);
+  Logger.log(LogLevel.DEBUG, `Decoded credential: ${JSON.stringify(decoded)}`);
 
   const parsedCredential = parseCredentialSdJwt(
     issuerConf.openid_credential_issuer.credential_configurations_supported,
@@ -232,8 +232,10 @@ const verifyAndParseCredentialSdJwt: WithFormat<"vc+sd-jwt"> = async (
   );
   const maybeIssuedAt = getValueFromDisclosures(decoded.disclosures, "iat");
 
-  Logger.log(LogLevel.DEBUG, `Parsed credential ${parsedCredential}`);
-  Logger.log(LogLevel.DEBUG, `Issued at ${maybeIssuedAt}`);
+  Logger.log(
+    LogLevel.DEBUG,
+    `Parsed credential: ${JSON.stringify(parsedCredential)}\nIssued at: ${maybeIssuedAt}`
+  );
 
   return {
     parsedCredential,

--- a/src/credential/status/02-status-attestation.ts
+++ b/src/credential/status/02-status-attestation.ts
@@ -64,10 +64,7 @@ export const statusAttestation: StatusAttestation = async (
     credential_pop: credentialPop,
   };
 
-  Logger.log(
-    LogLevel.DEBUG,
-    `Credential pop: ${JSON.stringify(credentialPop)}`
-  );
+  Logger.log(LogLevel.DEBUG, `Credential pop: ${credentialPop}`);
 
   const result = await appFetch(statusAttUrl, {
     method: "POST",

--- a/src/credential/status/03-verify-and-parse-status-attestation.ts
+++ b/src/credential/status/03-verify-and-parse-status-attestation.ts
@@ -46,7 +46,7 @@ export const verifyAndParseStatusAttestation: VerifyAndParseStatusAttestation =
 
       Logger.log(
         LogLevel.DEBUG,
-        `Parsed status attestation: ${parsedStatusAttestation}`
+        `Parsed status attestation: ${JSON.stringify(parsedStatusAttestation)}`
       );
 
       const holderBindingKey = await credentialCryptoContext.getPublicKey();

--- a/src/utils/par.ts
+++ b/src/utils/par.ts
@@ -106,7 +106,7 @@ export const makeParRequest =
 
     Logger.log(
       LogLevel.DEBUG,
-      `Sending ${formBody} to PAR endpoint ${parEndpoint}`
+      `Sending to PAR endpoint ${parEndpoint}: ${formBody}`
     );
 
     return await appFetch(parEndpoint, {

--- a/src/wallet-instance-attestation/issuing.ts
+++ b/src/wallet-instance-attestation/issuing.ts
@@ -95,7 +95,7 @@ export const getAttestation = async ({
   const challenge = await api.get("/nonce").then((response) => response.nonce);
   Logger.log(
     LogLevel.DEBUG,
-    `Challenge ${challenge} obtained from ${walletProviderBaseUrl}`
+    `Challenge obtained from ${walletProviderBaseUrl}: ${challenge} `
   );
 
   // 2. Get a signed attestation request
@@ -121,7 +121,10 @@ export const getAttestation = async ({
     .then((result) => TokenResponse.parse(result))
     .catch(handleAttestationCreationError);
 
-  Logger.log(LogLevel.DEBUG, `Obtained wallet attestation ${tokenResponse}`);
+  Logger.log(
+    LogLevel.DEBUG,
+    `Obtained wallet attestation: ${tokenResponse.wallet_attestation}`
+  );
 
   return tokenResponse.wallet_attestation;
 };

--- a/src/wallet-instance/index.ts
+++ b/src/wallet-instance/index.ts
@@ -21,7 +21,7 @@ export async function createWalletInstance(context: {
 
   Logger.log(
     LogLevel.DEBUG,
-    `Challenge ${challenge} obtained from ${context.walletProviderBaseUrl}`
+    `Challenge obtained from ${context.walletProviderBaseUrl}: ${challenge}`
   );
 
   const keyAttestation = await integrityContext.getAttestation(challenge);
@@ -30,7 +30,7 @@ export async function createWalletInstance(context: {
 
   Logger.log(
     LogLevel.DEBUG,
-    `Key attestation extracted from the device for hardware key tag ${hardwareKeyTag} - ${keyAttestation} `
+    `Key attestation: ${keyAttestation}\nAssociated hardware key tag: ${hardwareKeyTag}`
   );
 
   //2. Create Wallet Instance


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Fix a few logging strings which were not printed out correctly;
- Updates the logging context creation logic which now sets the custom remote transport only when a remote address is provided.
<!--- Describe your changes in detail -->

#### Motivation and Context
This PR fixes a few broken logging strings and also the logging context creation which now doesn't set the custom remote transport if a remote address hasn't been provided.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
- Uninstall the app;
- Reinstall the app;
- Try a random flow. The `TypeError` printed before each log in the console shouldn't appear if no address has been provided.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
