### PR TITLE
feat: [WLEO-353] Support for obtaining the new credential type eu.europa.ec.eudi.hiid.1

### DIFF
--- a/example/src/screens/CredentialScreen.tsx
+++ b/example/src/screens/CredentialScreen.tsx
@@ -34,6 +34,11 @@ export const CredentialScreen = () => {
   );
   const ts = useAppSelector(selectCredential("EuropeanHealthInsuranceCard"));
 
+  const healthIdState = useAppSelector(
+    selectCredentialAsyncStatus("eu.europa.ec.eudi.hiid.1")
+  );
+  const healthId = useAppSelector(selectCredential("eu.europa.ec.eudi.hiid.1"));
+
   useDebugInfo({
     mdlState,
     mdl,
@@ -41,6 +46,8 @@ export const CredentialScreen = () => {
     dc,
     tsState,
     ts,
+    healthIdState,
+    healthId,
   });
 
   const scenarios: Array<TestScenarioProp> = useMemo(
@@ -83,6 +90,18 @@ export const CredentialScreen = () => {
         icon: "healthCard",
         isPresent: !!ts,
       },
+      {
+        title: "Get credential (HealthId)",
+        onPress: () =>
+          dispatch(
+            getCredentialThunk({ credentialType: "eu.europa.ec.eudi.hiid.1" })
+          ),
+        isLoading: healthIdState.isLoading,
+        hasError: healthIdState.hasError,
+        isDone: healthIdState.isDone,
+        icon: "healthCard",
+        isPresent: !!healthId,
+      },
     ],
     [
       dc,
@@ -98,6 +117,10 @@ export const CredentialScreen = () => {
       tsState.hasError,
       tsState.isDone,
       tsState.isLoading,
+      healthId,
+      healthIdState.hasError,
+      healthIdState.isDone,
+      healthIdState.isLoading,
     ]
   );
 

--- a/example/src/store/reducers/credential.ts
+++ b/example/src/store/reducers/credential.ts
@@ -42,21 +42,25 @@ const initialState: CredentialState = {
     "org.iso.18013.5.1.mDL": undefined,
     EuropeanDisabilityCard: undefined,
     EuropeanHealthInsuranceCard: undefined,
+    "eu.europa.ec.eudi.hiid.1": undefined,
   },
   credentialsAsyncStatus: {
     "org.iso.18013.5.1.mDL": asyncStatusInitial,
     EuropeanDisabilityCard: asyncStatusInitial,
     EuropeanHealthInsuranceCard: asyncStatusInitial,
+    "eu.europa.ec.eudi.hiid.1": asyncStatusInitial,
   },
   statusAttestation: {
     "org.iso.18013.5.1.mDL": undefined,
     EuropeanDisabilityCard: undefined,
     EuropeanHealthInsuranceCard: undefined,
+    "eu.europa.ec.eudi.hiid.1": undefined,
   },
   statusAttAsyncStatus: {
     "org.iso.18013.5.1.mDL": asyncStatusInitial,
     EuropeanDisabilityCard: asyncStatusInitial,
     EuropeanHealthInsuranceCard: asyncStatusInitial,
+    "eu.europa.ec.eudi.hiid.1": asyncStatusInitial,
   },
 };
 

--- a/example/src/store/types.ts
+++ b/example/src/store/types.ts
@@ -36,6 +36,7 @@ export type SupportedCredentials =
   | "urn:eu.europa.ec.eudi:pid:1"
   | "org.iso.18013.5.1.mDL"
   | "EuropeanDisabilityCard"
+  | "eu.europa.ec.eudi.hiid.1"
   | "EuropeanHealthInsuranceCard";
 
 /**

--- a/example/src/thunks/presentation.ts
+++ b/example/src/thunks/presentation.ts
@@ -80,6 +80,10 @@ export const remoteCrossDevicePresentationThunk = createAppAsyncThunk<
   if (mDL?.credential) {
     credentialsMdoc.push([mDL.keyTag, mDL.credential]);
   }
+  const healthId = credentials["eu.europa.ec.eudi.hiid.1"];
+  if (healthId?.credential) {
+    credentialsMdoc.push([healthId.keyTag, healthId.credential]);
+  }
 
   const evaluateInputDescriptors =
     await Credential.Presentation.evaluateInputDescriptors(

--- a/example/src/utils/ui.ts
+++ b/example/src/utils/ui.ts
@@ -8,6 +8,7 @@ export const iconByCredentialType: Record<
   "org.iso.18013.5.1.mDL": "car",
   EuropeanDisabilityCard: "accessibility",
   EuropeanHealthInsuranceCard: "healthCard",
+  "eu.europa.ec.eudi.hiid.1": "healthCard",
 };
 
 export const labelByCredentialType: Record<
@@ -17,4 +18,5 @@ export const labelByCredentialType: Record<
   "org.iso.18013.5.1.mDL": "MDL",
   EuropeanDisabilityCard: "DC",
   EuropeanHealthInsuranceCard: "TS",
+  "eu.europa.ec.eudi.hiid.1": "HID",
 };

--- a/src/credential/issuance/06-obtain-credential.ts
+++ b/src/credential/issuance/06-obtain-credential.ts
@@ -131,7 +131,9 @@ export const obtainCredential: ObtainCredential = async (
 
   /** The credential request body */
   const credentialRequestFormBody = {
-    vct: credentialDefinition.credential_configuration_id,
+    ...(format === "mso_mdoc"
+      ? { doctype: credentialDefinition.credential_configuration_id }
+      : { vct: credentialDefinition.credential_configuration_id }),
     format,
     proof: {
       jwt: signedNonceProof,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
As explained below by Copilot.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR aims to add the support of obtaining the new credential type eu.europa.ec.eudi.hiid.1. It is needed to update the credential request body to conditionally use the "doctype" key for the "mso_mdoc" format.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
1. Navigate to "Credentials"
2. Click on "Get credential (HealthID)

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
