### PR TITLE
fix: [WLEO-406] Updated sd-jwt and mdoc credential parsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,9 @@
     ],
     "transformIgnorePatterns": [
       "node_modules/(?!(jest-)?@react-native|react-native|uuid|@pagopa/io-react-native-cbor)"
+    ],
+    "testPathIgnorePatterns": [
+      "/__tests__/utils"
     ]
   },
   "react-native-builder-bob": {

--- a/src/credential/issuance/07-verify-and-parse-credential.ts
+++ b/src/credential/issuance/07-verify-and-parse-credential.ts
@@ -64,7 +64,7 @@ type DecodedMDocCredential = Out<typeof verifyMdoc> & {
   issuerSigned: CBOR.IssuerSigned;
 };
 
-const parseCredentialSdJwt = (
+export const parseCredentialSdJwt = (
   // the list of supported credentials, as defined in the issuer configuration
   credentials_supported: Out<GetIssuerConfig>["issuerConf"]["credential_configurations_supported"],
   { sdJwt, disclosures }: DecodedSdJwtCredential,
@@ -92,7 +92,8 @@ const parseCredentialSdJwt = (
 
   // the key of the attribute defintion must match the disclosure's name
   const attrsNotInDisclosures = attrDefinitions.filter(
-    ([attrKey]) => !disclosures.some(([, name]) => name === attrKey)
+    ([attrKey, definition]) =>
+      !disclosures.some(([, name]) => name === attrKey) && definition.mandatory
   );
   if (attrsNotInDisclosures.length > 0) {
     const missing = attrsNotInDisclosures.map((_) => _[0 /* key */]).join(", ");
@@ -121,6 +122,8 @@ const parseCredentialSdJwt = (
             },
           ] as const
       )
+      //filter the not found elements
+      .filter(([_, definition]) => definition.value !== undefined)
       // add a human readable attribute name, with i18n, in the form { locale: name }
       // example: { "it-IT": "Nome", "en-EN": "Name", "es-ES": "Nombre" }
       .map(
@@ -155,11 +158,12 @@ const parseCredentialSdJwt = (
   return definedValues;
 };
 
-const parseCredentialMDoc = (
+export const parseCredentialMDoc = (
   // the list of supported credentials, as defined in the issuer configuration
   credentials_supported: Out<GetIssuerConfig>["issuerConf"]["credential_configurations_supported"],
   credential_type: string,
   { issuerSigned }: DecodedMDocCredential,
+  ignoreMissingAttributes: boolean = false,
   includeUndefinedAttributes: boolean = false
 ): ParsedCredential => {
   const credentialSubject = credentials_supported[credential_type];
@@ -208,6 +212,27 @@ const parseCredentialMDoc = (
     )
   );
 
+  // Check that all mandatory attributes defined in the issuer configuration are present in the disclosure set
+  // and filter the non present ones
+  const attrsNotInDisclosures = attrDefinitions.filter(
+    ([attrDefNamespace, attrKey, definition]) => {
+      const isClaimPresent = flatNamespaces.find(
+        ([namespace, name]) =>
+          attrDefNamespace === namespace && name === attrKey
+      );
+      return isClaimPresent === undefined && definition.mandatory;
+    }
+  );
+  if (attrsNotInDisclosures.length > 0) {
+    const missing = attrsNotInDisclosures.map((_) => _[0 /* key */]).join(", ");
+    const received = flatNamespaces.map((_) => _[1 /*name*/]);
+    if (!ignoreMissingAttributes) {
+      throw new IoWalletError(
+        `Some attributes are missing in the credential. Missing: [${missing}], received: [${received}]`
+      );
+    }
+  }
+
   // Attributes defined in the issuer configuration and present in the disclosure set
   const definedValues = Object.fromEntries(
     attrDefinitions
@@ -225,6 +250,8 @@ const parseCredentialMDoc = (
             },
           ] as const
       )
+      //filter the not found elements
+      .filter(([_, definition]) => definition.value !== undefined)
       // Add a human-readable attribute name, with i18n, in the form { locale: name }
       // Example: { "it-IT": "Nome", "en-EN": "Name", "es-ES": "Nombre" }
       .map(
@@ -410,6 +437,7 @@ const verifyAndParseCredentialMDoc: WithFormat<"mso_mdoc"> = async (
     issuerConf.credential_configurations_supported,
     credentialType,
     decoded,
+    undefined,
     ignoreMissingAttributes
   );
 

--- a/src/credential/issuance/__tests__/07-verify-and-parse-credentials.test.ts
+++ b/src/credential/issuance/__tests__/07-verify-and-parse-credentials.test.ts
@@ -1,0 +1,34 @@
+import { IoWalletError } from "../../../utils/errors";
+import "../07-verify-and-parse-credential";
+import {
+  parseCredentialMDoc,
+  parseCredentialSdJwt,
+} from "../07-verify-and-parse-credential";
+import { mocks } from "./utils/07-verify-and-parse-credentials-mocks";
+
+describe("parsingScenarios", () => {
+  it.each(mocks.map((s, index) => [`${index} : ${s.name}`, s]))(
+    "should parse without optional claims or throw if a mandatory claim is not found; %s",
+    (_, scenario) => {
+      if (scenario.throws) {
+        expect(() => {
+          if (scenario.input.format === "vc+sd-jwt") {
+            parseCredentialSdJwt(...scenario.input.parameters);
+          } else {
+            parseCredentialMDoc(...scenario.input.parameters);
+          }
+        }).toThrow(IoWalletError);
+      } else {
+        if (scenario.input.format === "vc+sd-jwt") {
+          expect(parseCredentialSdJwt(...scenario.input.parameters)).toEqual(
+            scenario.expected
+          );
+        } else {
+          expect(parseCredentialMDoc(...scenario.input.parameters)).toEqual(
+            scenario.expected
+          );
+        }
+      }
+    }
+  );
+});

--- a/src/credential/issuance/__tests__/utils/07-verify-and-parse-credentials-mocks.ts
+++ b/src/credential/issuance/__tests__/utils/07-verify-and-parse-credentials-mocks.ts
@@ -1,0 +1,615 @@
+import {
+  type TestScenario,
+  type ParseCredentialArg,
+  type ParseCredentialReturn,
+  buildMockSDJWTTestScenario,
+  buildMockMDOCTestScenario,
+} from "./07-verify-and-parse-credentials-utils";
+import { IoWalletError } from "../../../../utils/errors";
+
+export const mocks: TestScenario<
+  ParseCredentialArg,
+  ParseCredentialReturn,
+  Error
+>[] = [
+  // sd-jwt
+  {
+    name: "Mandatory claims = Disclosures, all mandatory",
+    input: {
+      format: "vc+sd-jwt",
+      parameters: buildMockSDJWTTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          given_name: {
+            display: [
+              {
+                name: "Nome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+        },
+        [
+          ["unused", "family_name", "Rossi"],
+          ["unused", "given_name", "Mario"],
+        ]
+      ),
+    },
+    expected: {
+      given_name: {
+        name: {
+          "it-IT": "Nome",
+        },
+        value: "Mario",
+        mandatory: true,
+      },
+      family_name: {
+        name: {
+          "it-IT": "Cognome",
+        },
+        value: "Rossi",
+        mandatory: true,
+      },
+    },
+  },
+  {
+    name: "Mandatory claims = Disclosures, not all mandatory",
+    input: {
+      format: "vc+sd-jwt",
+      parameters: buildMockSDJWTTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          given_name: {
+            display: [
+              {
+                name: "Nome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: false,
+          },
+        },
+        [
+          ["unused", "family_name", "Rossi"],
+          ["unused", "given_name", "Mario"],
+        ]
+      ),
+    },
+    expected: {
+      given_name: {
+        name: {
+          "it-IT": "Nome",
+        },
+        value: "Mario",
+        mandatory: false,
+      },
+      family_name: {
+        name: {
+          "it-IT": "Cognome",
+        },
+        value: "Rossi",
+        mandatory: true,
+      },
+    },
+  },
+  {
+    name: "Mandatory claims < Disclosures, all mandatory",
+    input: {
+      format: "vc+sd-jwt",
+      parameters: buildMockSDJWTTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+        },
+        [
+          ["unused", "family_name", "Rossi"],
+          ["unused", "given_name", "Mario"],
+        ]
+      ),
+    },
+    expected: {
+      given_name: {
+        name: "given_name",
+        value: "Mario",
+      },
+      family_name: {
+        name: {
+          "it-IT": "Cognome",
+        },
+        value: "Rossi",
+        mandatory: true,
+      },
+    },
+  },
+  {
+    name: "Mandatory claims < Disclosures, not all mandatory",
+    input: {
+      format: "vc+sd-jwt",
+      parameters: buildMockSDJWTTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          given_name: {
+            display: [
+              {
+                name: "Nome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: false,
+          },
+        },
+        [
+          ["unused", "family_name", "Rossi"],
+          ["unused", "given_name", "Mario"],
+          ["unused", "birth_date", new Date(2000, 2, 1)],
+        ]
+      ),
+    },
+    expected: {
+      given_name: {
+        name: {
+          "it-IT": "Nome",
+        },
+        value: "Mario",
+        mandatory: false,
+      },
+      family_name: {
+        name: {
+          "it-IT": "Cognome",
+        },
+        value: "Rossi",
+        mandatory: true,
+      },
+      birth_date: {
+        name: "birth_date",
+        value: new Date(2000, 2, 1),
+      },
+    },
+  },
+  {
+    name: "Mandatory claims > Disclosures, all mandatory",
+    input: {
+      format: "vc+sd-jwt",
+      parameters: buildMockSDJWTTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          given_name: {
+            display: [
+              {
+                name: "Nome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+        },
+        [["unused", "family_name", "Rossi"]]
+      ),
+    },
+    throws: new IoWalletError(),
+  },
+  {
+    name: "Mandatory claims > Disclosures, not all mandatory",
+    input: {
+      format: "vc+sd-jwt",
+      parameters: buildMockSDJWTTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          given_name: {
+            display: [
+              {
+                name: "Nome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          birth_date: {
+            display: [
+              {
+                name: "Data di nascita",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: false,
+          },
+        },
+        [["unused", "family_name", "Rossi"]]
+      ),
+    },
+    throws: new IoWalletError(),
+  },
+  {
+    name: "Non mandatory claim not found",
+    input: {
+      format: "vc+sd-jwt",
+      parameters: buildMockSDJWTTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          given_name: {
+            display: [
+              {
+                name: "Nome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: false,
+          },
+        },
+        [
+          ["unused", "family_name", "Rossi"],
+          ["unused", "birth_date", new Date(2000, 2, 1)],
+        ]
+      ),
+    },
+    expected: {
+      family_name: {
+        name: {
+          "it-IT": "Cognome",
+        },
+        value: "Rossi",
+        mandatory: true,
+      },
+      birth_date: {
+        name: "birth_date",
+        value: new Date(2000, 2, 1),
+      },
+    },
+  },
+  //MDOC
+  {
+    name: "Mandatory claims = Disclosures, all mandatory",
+    input: {
+      format: "mso_mdoc",
+      parameters: buildMockMDOCTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          given_name: {
+            display: [
+              {
+                name: "Nome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+        },
+        [
+          ["family_name", "Rossi"],
+          ["given_name", "Mario"],
+        ]
+      ),
+    },
+    expected: {
+      given_name: {
+        name: {
+          "it-IT": "Nome",
+        },
+        value: "Mario",
+        mandatory: true,
+      },
+      family_name: {
+        name: {
+          "it-IT": "Cognome",
+        },
+        value: "Rossi",
+        mandatory: true,
+      },
+    },
+  },
+  {
+    name: "Mandatory claims = Disclosures, not all mandatory",
+    input: {
+      format: "mso_mdoc",
+      parameters: buildMockMDOCTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          given_name: {
+            display: [
+              {
+                name: "Nome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: false,
+          },
+        },
+        [
+          ["family_name", "Rossi"],
+          ["given_name", "Mario"],
+        ]
+      ),
+    },
+    expected: {
+      given_name: {
+        name: {
+          "it-IT": "Nome",
+        },
+        value: "Mario",
+        mandatory: false,
+      },
+      family_name: {
+        name: {
+          "it-IT": "Cognome",
+        },
+        value: "Rossi",
+        mandatory: true,
+      },
+    },
+  },
+  {
+    name: "Mandatory claims < Disclosures, all mandatory",
+    input: {
+      format: "mso_mdoc",
+      parameters: buildMockMDOCTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+        },
+        [
+          ["family_name", "Rossi"],
+          ["given_name", "Mario"],
+        ]
+      ),
+    },
+    expected: {
+      given_name: {
+        name: "given_name",
+        value: "Mario",
+      },
+      family_name: {
+        name: {
+          "it-IT": "Cognome",
+        },
+        value: "Rossi",
+        mandatory: true,
+      },
+    },
+  },
+  {
+    name: "Mandatory claims < Disclosures, not all mandatory",
+    input: {
+      format: "mso_mdoc",
+      parameters: buildMockMDOCTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          given_name: {
+            display: [
+              {
+                name: "Nome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: false,
+          },
+        },
+        [
+          ["family_name", "Rossi"],
+          ["given_name", "Mario"],
+          ["birth_date", new Date(2000, 2, 1)],
+        ]
+      ),
+    },
+    expected: {
+      given_name: {
+        name: {
+          "it-IT": "Nome",
+        },
+        value: "Mario",
+        mandatory: false,
+      },
+      family_name: {
+        name: {
+          "it-IT": "Cognome",
+        },
+        value: "Rossi",
+        mandatory: true,
+      },
+      birth_date: {
+        name: "birth_date",
+        value: new Date(2000, 2, 1),
+      },
+    },
+  },
+  {
+    name: "Mandatory claims > Disclosures, all mandatory",
+    input: {
+      format: "mso_mdoc",
+      parameters: buildMockMDOCTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          given_name: {
+            display: [
+              {
+                name: "Nome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+        },
+        [["family_name", "Rossi"]]
+      ),
+    },
+    throws: new IoWalletError(),
+  },
+  {
+    name: "Mandatory claims > Disclosures, not all mandatory",
+    input: {
+      format: "mso_mdoc",
+      parameters: buildMockMDOCTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          given_name: {
+            display: [
+              {
+                name: "Nome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          birth_date: {
+            display: [
+              {
+                name: "Data di nascita",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: false,
+          },
+        },
+        [["family_name", "Rossi"]]
+      ),
+    },
+    throws: new IoWalletError(),
+  },
+  {
+    name: "Not mandatory claim not found",
+    input: {
+      format: "mso_mdoc",
+      parameters: buildMockMDOCTestScenario(
+        {
+          family_name: {
+            display: [
+              {
+                name: "Cognome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: true,
+          },
+          given_name: {
+            display: [
+              {
+                name: "Nome",
+                locale: "it-IT",
+              },
+            ],
+            mandatory: false,
+          },
+        },
+        [
+          ["family_name", "Rossi"],
+          ["birth_date", new Date(2000, 2, 1)],
+        ]
+      ),
+    },
+    expected: {
+      family_name: {
+        name: {
+          "it-IT": "Cognome",
+        },
+        value: "Rossi",
+        mandatory: true,
+      },
+      birth_date: {
+        name: "birth_date",
+        value: new Date(2000, 2, 1),
+      },
+    },
+  },
+];

--- a/src/credential/issuance/__tests__/utils/07-verify-and-parse-credentials-utils.ts
+++ b/src/credential/issuance/__tests__/utils/07-verify-and-parse-credentials-utils.ts
@@ -1,0 +1,168 @@
+import type {
+  parseCredentialMDoc,
+  parseCredentialSdJwt,
+} from "../../07-verify-and-parse-credential";
+
+export type TestScenario<
+  T extends object,
+  R extends object,
+  E extends Error,
+> = {
+  name: string;
+  input: T;
+  expected?: R;
+  throws?: E;
+};
+
+export type ParseCredentialArg =
+  | {
+      format: "vc+sd-jwt";
+      parameters: Parameters<typeof parseCredentialSdJwt>;
+    }
+  | {
+      format: "mso_mdoc";
+      parameters: Parameters<typeof parseCredentialMDoc>;
+    };
+
+export type ClaimsSdJwt =
+  | Record<
+      string,
+      {
+        display: {
+          name: string;
+          locale: string;
+        }[];
+        mandatory: boolean;
+      }
+    >
+  | Record<
+      string,
+      Record<
+        string,
+        {
+          display: {
+            name: string;
+            locale: string;
+          }[];
+          mandatory: boolean;
+        }
+      >
+    >;
+
+export type ClaimsMDOC = Record<
+  string,
+  {
+    display: {
+      name: string;
+      locale: string;
+    }[];
+    mandatory: boolean;
+  }
+>;
+
+export type ParseCredentialReturn = Record<
+  string,
+  {
+    name?: string | Record<string, string>;
+    value: unknown;
+    mandatory?: boolean;
+  }
+>;
+
+export function buildMockMDOCTestScenario(
+  claims: ClaimsMDOC,
+  nameSpaces: [string, any][]
+): Parameters<typeof parseCredentialMDoc> {
+  return [
+    {
+      "org.iso.18013.5.1.mDL": {
+        cryptographic_suites_supported: [],
+        cryptographic_binding_methods_supported: [],
+        format: "mso_mdoc",
+        display: [],
+        claims: {
+          "org.iso.18013.5.1": claims,
+        },
+      },
+    },
+    "org.iso.18013.5.1.mDL",
+    {
+      issuerSigned: {
+        nameSpaces: {
+          "org.iso.18013.5.1": nameSpaces.map((namespace) => ({
+            elementIdentifier: namespace[0],
+            elementValue: namespace[1],
+          })),
+        },
+        issuerAuth: {
+          unprotectedHeader: [],
+          protectedHeader: "unused",
+          payload: {
+            validityInfo: {
+              signed: new Date(2000, 2, 1),
+              validFrom: new Date(2000, 2, 1),
+              validUntil: new Date(2000, 2, 1),
+            },
+            deviceKeyInfo: {
+              deviceKey: {
+                kty: "EC",
+                crv: "P-256",
+                x: "unused",
+                y: "unused",
+              },
+            },
+            valueDigests: {},
+          },
+        },
+      },
+    },
+    false,
+    true,
+  ];
+}
+
+export function buildMockSDJWTTestScenario(
+  claims: ClaimsSdJwt,
+  disclosures: [string, string, unknown][]
+): Parameters<typeof parseCredentialSdJwt> {
+  return [
+    {
+      "eu.europa.ec.eudi.pid.1": {
+        cryptographic_suites_supported: [],
+        cryptographic_binding_methods_supported: [],
+        format: "vc+sd-jwt",
+        display: [],
+        claims,
+      },
+    },
+    {
+      sdJwt: {
+        header: {
+          typ: "vc+sd-jwt",
+          alg: "unused",
+        },
+        payload: {
+          status: {
+            status_assertion: {
+              credential_hash_alg: "sha-256",
+            },
+          },
+          vct: "eu.europa.ec.eudi.pid.1",
+          iss: "unused",
+          sub: "unused",
+          exp: 0,
+          _sd_alg: "sha-256",
+          cnf: {
+            jwk: {
+              kty: "RSA",
+            },
+          },
+          _sd: [],
+        },
+      },
+      disclosures,
+    },
+    false,
+    true,
+  ];
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR updates `sd-jwt` and `mdoc` credential parsers to exclude non mandatory claims that are not present in the credentials and throw errors in case mandatory claims are not present.

#### List of Changes

- Added filtering in `parseCredentialSdJwt` and `parseCredentialMDoc` to exclude claims defined in the `issuerConfig`s as non mandatory and not present in the obtained credential
- Added check in `parseCredentialMDoc` that throws an error when a credential doesn't contain mandatory, claims, adapted from `parseCredentialSdJwt`'s own check
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR solves an issue for which some credentials' claims were not rendered correctly because they were only defined in the `issuerConf`, and not in the credential itself.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The new functionalities have been tested with specific unit tests whose passing is a necessary condition for merging this PR.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
