### PR TITLE
deps: [WLEO-439] Update CBOR and x5chain parameter when verifying credential 

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -7,12 +7,12 @@ PODS:
   - hermes-engine (0.75.5):
     - hermes-engine/Pre-built (= 0.75.5)
   - hermes-engine/Pre-built (0.75.5)
-  - IoReactNativeCbor (1.2.4):
+  - IoReactNativeCbor (1.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
-    - IOWalletCBOR (~> 0.0.9)
-    - IOWalletProximity (~> 1.0.1)
+    - IOWalletCBOR (~> 0.1.0)
+    - IOWalletProximity (~> 1.2.1)
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -30,8 +30,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - IOWalletCBOR (0.0.9)
-  - IOWalletProximity (1.0.1)
+  - IOWalletCBOR (0.1.0)
+  - IOWalletProximity (1.2.1)
   - JOSESwift (3.0.0)
   - pagopa-io-react-native-crypto (0.2.3):
     - React-Core
@@ -1965,9 +1965,9 @@ SPEC CHECKSUMS:
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
   hermes-engine: c9fe5870af65876125fdbbf833071b6f329db30d
-  IoReactNativeCbor: 1e3d83bf51f6dd80cdf4613ce7d7925792d141e4
-  IOWalletCBOR: 016de622a863910c0ac6dab3356e1d1d3b272091
-  IOWalletProximity: fed5a3163c70a81b032db0871542ff0bb03fca13
+  IoReactNativeCbor: 5493cc41b75d7e59370f7b606871cb9cb0d5451b
+  IOWalletCBOR: f6147a29e88bfd3ef36386840df1b5f907c3ae41
+  IOWalletProximity: 66db020e9570b5b14483090336a7cdc3b0418e7c
   JOSESwift: 7784b1b844194d0f534eb6ac4fba5af683bccc79
   pagopa-io-react-native-crypto: 93f984df8711eb72f3fb030eca51be6268fc96d6
   pagopa-io-react-native-jwt: 849b368d5d110849a4a8cc30480e6fc8eceb0cc2

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@pagopa/io-app-design-system": "^1.43.0",
-    "@pagopa/io-react-native-cbor": "^1.2.4",
+    "@pagopa/io-react-native-cbor": "^1.4.0",
     "@pagopa/io-react-native-crypto": "^0.2.3",
     "@pagopa/io-react-native-jwt": "^2.1.0",
     "@pagopa/io-react-native-login-utils": "^1.0.8",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2141,10 +2141,10 @@
     react-native-svg "^15.1.0"
     rn-placeholder "1.3.3"
 
-"@pagopa/io-react-native-cbor@^1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-cbor/-/io-react-native-cbor-1.2.4.tgz#5a60832a8183d4d90fff380bc2144754eefa5a42"
-  integrity sha512-Hqtr8iHng9a8eyrRHEtTlpqiiiC8YFMGwTzWYk+RPpTjUDzxIRqDqkbKyk9Y6/gV3dru+CAajvQW5Cmf3zIZcw==
+"@pagopa/io-react-native-cbor@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-cbor/-/io-react-native-cbor-1.4.0.tgz#125b8cd31597fc537a8ce263f6a4e3c2c2d099dd"
+  integrity sha512-1jyckAlVRGO3SPR6kBbhqd3PhwNyAKq58ITI9Dztb+waiUmbuUSukkTfBCrJquz1rgwVuSyCDvJHIJsx64rwzA==
   dependencies:
     zod "^3.24.1"
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@pagopa/io-react-native-crypto": "^0.2.3",
     "@pagopa/io-react-native-jwt": "^2.1.0",
-    "@pagopa/io-react-native-cbor": "^1.2.4",
+    "@pagopa/io-react-native-cbor": "^1.4.0",
     "@react-native/eslint-config": "^0.75.5",
     "@rushstack/eslint-patch": "^1.3.2",
     "@types/jest": "^28.1.2",

--- a/src/mdoc/index.ts
+++ b/src/mdoc/index.ts
@@ -20,7 +20,7 @@ export const verify = async (
     throw new Error("Invalid mDoc");
   }
 
-  const cert = issuerSigned.issuerAuth.unprotectedHeader[0]?.keyId;
+  const cert = issuerSigned.issuerAuth.unprotectedHeader[0]?.x5chain?.[0];
   if (!cert) throw new Error("Certificate not present in credential");
 
   const pemcert = convertCertToPem(b64utob64(cert));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2380,10 +2380,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pagopa/io-react-native-cbor@^1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-cbor/-/io-react-native-cbor-1.2.4.tgz#5a60832a8183d4d90fff380bc2144754eefa5a42"
-  integrity sha512-Hqtr8iHng9a8eyrRHEtTlpqiiiC8YFMGwTzWYk+RPpTjUDzxIRqDqkbKyk9Y6/gV3dru+CAajvQW5Cmf3zIZcw==
+"@pagopa/io-react-native-cbor@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-cbor/-/io-react-native-cbor-1.4.0.tgz#125b8cd31597fc537a8ce263f6a4e3c2c2d099dd"
+  integrity sha512-1jyckAlVRGO3SPR6kBbhqd3PhwNyAKq58ITI9Dztb+waiUmbuUSukkTfBCrJquz1rgwVuSyCDvJHIJsx64rwzA==
   dependencies:
     zod "^3.24.1"
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
#### List of Changes
- Update `io-react-native-cbor` to version `1.4.0`;
- Change the `keyId` parameter to `x5chain`. Currently only the first certificate in the chain is used.
<!--- Describe your changes in detail -->

#### Motivation and Context
This PR updates `io-react-native-cbor` to the latest version to avoid conflicts while installing this library alongside `io-react-native-proximity` due to a shared dependency.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Try to obtain a mDL. The parsing should succeed. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
