### PR TITLE
fix: [WLEO-439] Changed behavior of evaluateInputDescriptor helper functions to throw on no match

### DIFF
--- a/src/credential/presentation/07-evaluate-input-descriptor.ts
+++ b/src/credential/presentation/07-evaluate-input-descriptor.ts
@@ -253,6 +253,12 @@ export const evaluateInputDescriptorForMdoc: EvaluateInputDescriptorMdoc = (
     );
   }
 
+  if (requiredDisclosures.length === 0 && optionalDisclosures.length === 0) {
+    throw new MissingDataError(
+      "Credential validation failed: No required fields were requested and no optional field has been requested or found."
+    );
+  }
+
   return {
     requiredDisclosures,
     optionalDisclosures,
@@ -345,6 +351,12 @@ export const evaluateInputDescriptorForSdJwt4VC: EvaluateInputDescriptorSdJwt4VC
     if (!allFieldsValid) {
       throw new MissingDataError(
         "Credential validation failed: Required fields are missing or do not match the input descriptor."
+      );
+    }
+
+    if (requiredDisclosures.length === 0 && optionalDisclosures.length === 0) {
+      throw new MissingDataError(
+        "Credential validation failed: No required fields were requested and no optional field has been requested or found."
       );
     }
 

--- a/src/credential/presentation/__tests__/07-evaluate-input-descriptor.test.ts
+++ b/src/credential/presentation/__tests__/07-evaluate-input-descriptor.test.ts
@@ -84,7 +84,7 @@ describe("evaluateInputDescriptorForSdJwt4VC", () => {
     ).toThrow(); // Required field not satisfied
   });
 
-  it("should pass if a field path does not exist but is optional", () => {
+  it("should throw if a field path does not exist but is optional", () => {
     const inputDescriptor: InputDescriptor = {
       id: "testDescriptor",
       name: "test",
@@ -111,13 +111,13 @@ describe("evaluateInputDescriptorForSdJwt4VC", () => {
       },
     ];
 
-    const { requiredDisclosures } = evaluateInputDescriptorForSdJwt4VC(
-      inputDescriptor,
-      payloadCredential,
-      disclosures
-    );
-    // Because the field is optional, we keep the original disclosures
-    expect(requiredDisclosures).toEqual([]);
+    expect(() => {
+      evaluateInputDescriptorForSdJwt4VC(
+        inputDescriptor,
+        payloadCredential,
+        disclosures
+      );
+    }).toThrow();
   });
 
   it("should pass if a field path required and another is optional", () => {
@@ -340,7 +340,7 @@ describe("evaluateInputDescriptorForMdoc", () => {
     ).toThrow(); // Required field not satisfied
   });
 
-  it("should pass if a field path does not exist but is optional", () => {
+  it("should throw if a field path does not exist but is optional", () => {
     const inputDescriptor: InputDescriptor = {
       id: "testDescriptor",
       name: "test",
@@ -354,11 +354,9 @@ describe("evaluateInputDescriptorForMdoc", () => {
       },
     };
 
-    const { requiredDisclosures, optionalDisclosures } =
-      evaluateInputDescriptorForMdoc(inputDescriptor, minimalPayloadCredential);
-    // Because the field is optional, we keep the original disclosures
-    expect(requiredDisclosures).toEqual([]);
-    expect(optionalDisclosures).toEqual([]);
+    expect(() =>
+      evaluateInputDescriptorForMdoc(inputDescriptor, minimalPayloadCredential)
+    ).toThrow();
   });
 
   it("should pass if a field path required and another is optional", () => {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR changes the behavior of the `evaluateInputDescriptorForMdoc` and `evaluateInputDescriptorForSdJwt4VC` methods to solve a bug regarding presentations containing only optional values.

#### List of Changes

<!--- Describe your changes in detail -->
- `src/credential/presentation/__tests__/07-evaluate-input-descriptor.test.ts`, `src/credential/presentation/__tests__/07-evaluate-input-descriptor.ts` : made the methods `evaluateInputDescriptorFor*` has been changed to throw in case no matches are found for a credential, optional or not. Tests have been modified accordingly.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The `findCredentialSdJwt` and `findCredentialMdoc` use their corresponding `evaluateInputDescriptorFor*` methods' logic to handle matching of the input descriptor with a credential's claims, more precisely they switch to the next credential upon the method throwing an error, and return its matches upon successful invocation. 

Before this change, this function returned at the first credential in case an input descriptor with zero required disclosures and optional disclosures was passed, thus stopping the credentials' parsing process.

This has led to the following unwanted scenario:

0. The RP generates an input descriptor containing no required disclosures and some optional disclosures, which are contained in a credential B. When passing the input descriptor in search for matches, the credential array is the following: `[A,B]`.
1. The parser tries to find disclosures in credential A, it being the first in the array, "matches" all required disclosures (for there were none), and doesn't find any of the optional disclosures, but, being that the required disclosures check passes, the `evaluateInputDescriptor` method succeeds, and credential B is not searched, so the `findCredential*` method returns that no match has been found, despite the claims being present in credential B.

To fix this, now the `evaluateInputDescriptorFor*` methods throw an error if zero matches, optional or not, are found, too.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
0. The original tests for the changed methods have been updated to comply to the new specification.
1. Despite the example app doesn't support optional disclosure selection, some presentation to various RPs have been done to check for regressions.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
