### PR TITLE
ci: [SIW-2534] allow publishing to NPM under a prerelease tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,6 +22,12 @@ jobs:
       - name: Generate client
         run: yarn generate
       - name: Publish package on NPM 📦
-        run: npm publish --access=public
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *"-next."* ]]; then
+            npm publish --access=public --tag=next
+          else
+            npm publish --access=public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,8 +24,8 @@ jobs:
       - name: Publish package on NPM 📦
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          if [[ "$VERSION" == *"-next."* ]]; then
-            npm publish --access=public --tag=next
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-([a-zA-Z]+)\.[0-9]+$ ]]; then
+            npm publish --access=public --tag=${BASH_REMATCH[1]}
           else
             npm publish --access=public
           fi


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Edit the `publish.yaml` workflow

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR allows publishing to NPM under arbitrary prerelease tags (es. `next`, `rc`). The prerelease tag is dinamically extracted from the version in `package.json`.

The rationale is to allow publishing unstable versions to NPM without overriding the `latest` tag.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
