### PR TITLE
ci: create separate job to check release name and fix publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,10 +14,10 @@ jobs:
         id: check_title
         run: |
           if echo "${{ github.event.release.name }}" | grep -iq 'example'; then
-            echo "should_skip=true" >> $GITHUB_OUTPUT
+            echo "should_skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "Release title is valid. Proceeding with the workflow."
-            echo "should_skip=false" >> $GITHUB_OUTPUT
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
           fi
 
   build:


### PR DESCRIPTION
#### Motivation and Context

This PR fixes a problem in the publish workflow when the release name is checked: the function `toLower` is not valid in GitHub expressions. Additionally, the if condition was at the single step level, not at the job level.

The PR adds a separate job to check the release name and uses [GitHub outputs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs) to pass the information to the build job.
