### PR TITLE
chore: update @pagopa/io-react-native-crypto to version 1.2.2

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - hermes-engine/Pre-built (0.75.5)
   - JOSESwift (3.0.0)
   - OpenSSL-Universal (3.3.3001)
-  - pagopa-io-react-native-crypto (1.2.1):
+  - pagopa-io-react-native-crypto (1.2.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2010,7 +2010,7 @@ SPEC CHECKSUMS:
   hermes-engine: c9fe5870af65876125fdbbf833071b6f329db30d
   JOSESwift: 7784b1b844194d0f534eb6ac4fba5af683bccc79
   OpenSSL-Universal: 6082b0bf950e5636fe0d78def171184e2b3899c2
-  pagopa-io-react-native-crypto: 8a796cd6d350cc024197f7f1621fa2d65eb44ac7
+  pagopa-io-react-native-crypto: bcb3de29a2a59dbd48cd68e8a8c33622e9fd0276
   pagopa-io-react-native-integrity: 48c93d245cfea4bcbfeaab76ab5cda83e0e9c8c0
   pagopa-io-react-native-jwt: 4f1c348d8260f0dc882412243531b3a516608e97
   pagopa-io-react-native-secure-storage: 0297d41360d93f89e9f89c8412b99916e0dbf520

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@pagopa/io-app-design-system": "^1.43.0",
-    "@pagopa/io-react-native-crypto": "^1.1.3",
+    "@pagopa/io-react-native-crypto": "^1.2.2",
     "@pagopa/io-react-native-integrity": "^0.3.1",
     "@pagopa/io-react-native-jwt": "^2.1.0",
     "@pagopa/io-react-native-secure-storage": "^0.2.0",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2141,10 +2141,10 @@
     react-native-svg "^15.1.0"
     rn-placeholder "1.3.3"
 
-"@pagopa/io-react-native-crypto@^1.1.3":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-crypto/-/io-react-native-crypto-1.2.1.tgz#89f7ea4c720f6cde204e1b6b24a113feaf2ba493"
-  integrity sha512-O7pucZCK9D+SWcmmBmB66P6XL/OPXLJm8k2zNYCgjf4OR2o6Kn/Vbzkk6JptraG2EgGL1iKvjNc7hJxd0YTh+g==
+"@pagopa/io-react-native-crypto@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-crypto/-/io-react-native-crypto-1.2.2.tgz#b7e6494e7eb40f2116d2f839031a8ba89209054c"
+  integrity sha512-s2M3c+xjpLYFyPJ2pMu+aePuWMMEMTHr5pONUZ66w/S7o+QnbRMpDjz+qaB57eCB6pBcGGY+iLXxD/JEXTxfZQ==
 
 "@pagopa/io-react-native-integrity@^0.3.1":
   version "0.3.1"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@pagopa/io-react-native-crypto": "^1.1.3",
+    "@pagopa/io-react-native-crypto": "^1.2.2",
     "@pagopa/io-react-native-jwt": "^2.1.0",
     "@react-native/eslint-config": "^0.75.5",
     "@rushstack/eslint-patch": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2380,10 +2380,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pagopa/io-react-native-crypto@^1.1.3":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-crypto/-/io-react-native-crypto-1.2.1.tgz#89f7ea4c720f6cde204e1b6b24a113feaf2ba493"
-  integrity sha512-O7pucZCK9D+SWcmmBmB66P6XL/OPXLJm8k2zNYCgjf4OR2o6Kn/Vbzkk6JptraG2EgGL1iKvjNc7hJxd0YTh+g==
+"@pagopa/io-react-native-crypto@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-crypto/-/io-react-native-crypto-1.2.2.tgz#b7e6494e7eb40f2116d2f839031a8ba89209054c"
+  integrity sha512-s2M3c+xjpLYFyPJ2pMu+aePuWMMEMTHr5pONUZ66w/S7o+QnbRMpDjz+qaB57eCB6pBcGGY+iLXxD/JEXTxfZQ==
 
 "@pagopa/io-react-native-jwt@^2.1.0":
   version "2.1.0"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Update @pagopa/io-react-native-crypto to version 1.2.2 to support RN 0.78

