### PR TITLE
fix: [WLEO-496] Fix OpenID Federation EC parser

### DIFF
--- a/src/credential/issuance/02-get-issuer-config.ts
+++ b/src/credential/issuance/02-get-issuer-config.ts
@@ -111,15 +111,20 @@ const credentialIssuerRationalizationOIDFED = (
       ).map(([key, config]) => {
         const claimsRaw = config.claims;
 
-        const claims : CredentialConfigurationSupported[string]["claims"] = Object.entries(claimsRaw).map(([, v]) => ({
+        const claims: CredentialConfigurationSupported[string]["claims"] =
+          Object.entries(claimsRaw)
+            .map(([, v]) => ({
               path: v.path,
               details: {
                 mandatory: v.mandatory,
                 display: v.display,
               },
-          })).reduce((cumulated, entry) =>
-              pathInsert(cumulated, entry.path, entry.details)
-            ,{})
+            }))
+            .reduce(
+              (cumulated, entry) =>
+                pathInsert(cumulated, entry.path, entry.details),
+              {}
+            );
 
         const newConfig: CredentialConfigurationSupported[string] = {
           ...config,

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -73,3 +73,23 @@ export const safeJsonParse = <T>(text: string, withDefault?: T): T | null => {
     return withDefault ?? null;
   }
 };
+
+/**
+ * Helper function to insert a value at a specified object path
+ * @param object The object in which to insert the value
+ * @param path The path at which the value should be inserted
+ * @param value The value to insert at the specified path
+ * @returns A new object with the property at path set to value, on-path objects are recreated
+ */
+export function pathInsert(object: any, path: string[], value: any) : any {
+  if (path.length === 1) {
+    return {
+      ...object,
+      [path[0]!] : value
+    }
+  }
+  return {
+    ...object,
+    [path[0]!] : pathInsert(path[0]! in object ? object[path[0]!] : {}, path.slice(1), value)
+  }
+}

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -81,15 +81,19 @@ export const safeJsonParse = <T>(text: string, withDefault?: T): T | null => {
  * @param value The value to insert at the specified path
  * @returns A new object with the property at path set to value, on-path objects are recreated
  */
-export function pathInsert(object: any, path: string[], value: any) : any {
+export function pathInsert(object: any, path: string[], value: any): any {
   if (path.length === 1) {
     return {
       ...object,
-      [path[0]!] : value
-    }
+      [path[0]!]: value,
+    };
   }
   return {
     ...object,
-    [path[0]!] : pathInsert(path[0]! in object ? object[path[0]!] : {}, path.slice(1), value)
-  }
+    [path[0]!]: pathInsert(
+      path[0]! in object ? object[path[0]!] : {},
+      path.slice(1),
+      value
+    ),
+  };
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Fixed OIDFED EC parser by making it use the full EC path instead of just a coordinate and removed Potential retrocompatibility.


#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR solves mDoc compatibility issues in the OpenID Federation EC parsing.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The changes have been tested on a real EC from an application that uses this library as a dependency.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
