### PR TITLE
chore: add Wallet Attestation in remote presentation in the example app

### DIFF
--- a/example/src/thunks/presentation.ts
+++ b/example/src/thunks/presentation.ts
@@ -4,7 +4,7 @@ import {
   Credential,
 } from "@pagopa/io-react-native-wallet";
 import {
-  selectAttestationAsJwt,
+  selectAttestationAsSdJwt,
   shouldRequestAttestationSelector,
 } from "../store/reducers/attestation";
 import { getAttestationThunk } from "./attestation";
@@ -13,6 +13,7 @@ import { selectPid } from "../store/reducers/pid";
 import { selectCredentials } from "../store/reducers/credential";
 import { isDefined } from "../utils/misc";
 import type { CryptoContext } from "@pagopa/io-react-native-jwt";
+import { WIA_KEYTAG } from "../utils/crypto";
 
 export type RequestObject = Awaited<
   ReturnType<Credential.Presentation.VerifyRequestObject>
@@ -58,11 +59,6 @@ export const remoteCrossDevicePresentationThunk = createAppAsyncThunk<
     await dispatch(getAttestationThunk());
   }
 
-  // Gets the Wallet Instance Attestation from the persisted store
-  const walletInstanceAttestation = selectAttestationAsJwt(getState());
-  if (!walletInstanceAttestation) {
-    throw new Error("Wallet Instance Attestation not found");
-  }
   const url = new URL(args.qrcode);
 
   const qrParams = Credential.Presentation.startFlowFromQR({
@@ -95,9 +91,16 @@ export const remoteCrossDevicePresentationThunk = createAppAsyncThunk<
     throw new Error("PID not found");
   }
 
+  const walletInstanceAttestation = selectAttestationAsSdJwt(getState());
+  if (!walletInstanceAttestation) {
+    throw new Error("Wallet Instance Attestation not found");
+  }
+
   const credentials = selectCredentials(getState());
+
   const credentialsSdJwt = [
     [createCryptoContextFor(pid.keyTag), pid.credential],
+    [createCryptoContextFor(WIA_KEYTAG), walletInstanceAttestation],
     ...Object.values(credentials)
       .filter(isDefined)
       .map((c) => [createCryptoContextFor(c.keyTag), c.credential]),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Included the Wallet Attestation among the credentials used for remote presentation (example app)
