### PR TITLE
fix: [SIW-2785] Improve kid string comparison with thumbprint-based key comparison on credential flow

### DIFF
--- a/__mocks__/@pagopa/io-react-native-jwt/index.ts
+++ b/__mocks__/@pagopa/io-react-native-jwt/index.ts
@@ -17,7 +17,16 @@ function mockHexToBase64(hexstring: string) {
   return btoa(g);
 }
 
-export const thumbprint = (_: any) => sha256ToBase64(JSON.stringify(_));
+export const thumbprint = (jwk: any) => {
+  const canonical = {
+    crv: jwk.crv,
+    kty: jwk.kty,
+    x: jwk.x,
+    y: jwk.y,
+  };
+  const canonicalJson = JSON.stringify(canonical);
+  return sha256ToBase64(canonicalJson);
+};
 
 export function removePadding(encoded: string): string {
   // eslint-disable-next-line no-div-regex

--- a/src/credential/issuance/07-verify-and-parse-credential.ts
+++ b/src/credential/issuance/07-verify-and-parse-credential.ts
@@ -4,7 +4,7 @@ import type { EvaluateIssuerTrust } from "./02-evaluate-issuer-trust";
 import { IoWalletError } from "../../utils/errors";
 import { SdJwt4VC, verify as verifySdJwt } from "../../sd-jwt";
 import { getValueFromDisclosures } from "../../sd-jwt/converters";
-import type { JWK } from "../../utils/jwk";
+import { isSameThumbprint, type JWK } from "../../utils/jwk";
 import type { ObtainCredential } from "./06-obtain-credential";
 import { Logger, LogLevel } from "../../utils/logging";
 
@@ -168,8 +168,7 @@ async function verifyCredentialSdJwt(
     ]);
 
   const { cnf } = decodedCredential.sdJwt.payload;
-
-  if (!cnf.jwk.kid || cnf.jwk.kid !== holderBindingKey.kid) {
+  if (!(await isSameThumbprint(cnf.jwk, holderBindingKey as JWK))) {
     const message = `Failed to verify holder binding, expected kid: ${holderBindingKey.kid}, got: ${decodedCredential.sdJwt.payload.cnf.jwk.kid}`;
     Logger.log(LogLevel.ERROR, message);
     throw new IoWalletError(message);

--- a/src/credential/issuance/__tests__/07-verify-and-parse-credential.test.ts
+++ b/src/credential/issuance/__tests__/07-verify-and-parse-credential.test.ts
@@ -10,7 +10,6 @@ describe("verifyAndParseCredential", () => {
     getPublicKey: async () => ({
       kty: "EC",
       crv: "P-256",
-      kid: "Rv3W-EiKpvBTyk5yZxvrev-7MDB6SlzUCBo_CQjjddU",
       x: "0Wox7QtyPqByg35MH_XyCcnd5Le-Jm0AXHlUgDBA03Y",
       y: "eEhVvg1JPqNd3DTSa4mGDGBlwY6NP-EZbLbNFXSXwIg",
     }),

--- a/src/credential/status/03-verify-and-parse-status-assertion.ts
+++ b/src/credential/status/03-verify-and-parse-status-assertion.ts
@@ -4,17 +4,16 @@ import {
   IssuerResponseError,
   IssuerResponseErrorCodes,
 } from "../../utils/errors";
-import { verify } from "@pagopa/io-react-native-jwt";
+import { decode as decodeJwt, verify } from "@pagopa/io-react-native-jwt";
 import type { EvaluateIssuerTrust, StatusAssertion } from ".";
 import {
+  type InvalidStatusErrorReason,
   ParsedStatusAssertion,
   ParsedStatusAssertionError,
   ParsedStatusAssertionResponse,
   StatusType,
-  type InvalidStatusErrorReason,
 } from "./types";
-import { decode as decodeJwt } from "@pagopa/io-react-native-jwt";
-import { LogLevel, Logger } from "../../utils/logging";
+import { Logger, LogLevel } from "../../utils/logging";
 import type { ObtainCredential } from "../issuance";
 import { extractJwkFromCredential } from "../../utils/credentials";
 import { isSameThumbprint } from "../../utils/jwk";
@@ -71,7 +70,7 @@ export const verifyAndParseStatusAssertion: VerifyAndParseStatusAssertion =
     const { cnf, credential_status_type } = parsedStatusAssertion.payload;
     const holderBindingKey = await extractJwkFromCredential(credential, format);
 
-    if (!isSameThumbprint(cnf.jwk, holderBindingKey)) {
+    if (!(await isSameThumbprint(cnf.jwk, holderBindingKey))) {
       const errorMessage = `Failed to verify holder binding for status assertion: the thumbprints of keys ${cnf.jwk.kid} and ${holderBindingKey.kid} do not match`;
       Logger.log(LogLevel.ERROR, errorMessage);
       throw new IoWalletError(errorMessage);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR enhances the `verifyCredentialSdJwt` function by replacing the kid string comparison with a more robust thumbprint-based key comparison.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change replaces the kid comparison with a JWK thumbprint check to ensure reliable holder binding verification, avoiding mismatches due to inconsistent or missing kid values. It improves robustness and aligns with best practices.
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Test a complete issuing flow obtaining PID + Credentials

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
