### PR TITLE
fix: [SIW-2800] zod type for claims path pointer

### DIFF
--- a/example/.env.example
+++ b/example/.env.example
@@ -10,8 +10,8 @@ PRE_LOGGING_SERVER="https://localhost:8080/sendLogs"
 
 # PROD SECTION
 PROD_WALLET_PROVIDER_BASE_URL='https://api-app.io.pagopa.it/api/v1/wallet'
-PROD_WALLET_PID_PROVIDER_BASE_URL='https://eid.wallet.ipzs.it'
-PROD_WALLET_EAA_PROVIDER_BASE_URL='https://eaa.wallet.ipzs.it'
+PROD_WALLET_PID_PROVIDER_BASE_URL='https://eid.wallet.ipzs.it/1-0'
+PROD_WALLET_EAA_PROVIDER_BASE_URL='https://eaa.wallet.ipzs.it/1-0'
 PROD_WALLET_TA_BASE_URL='https://ta.wallet.ipzs.it'
 PROD_REDIRECT_URI='iowalletexample://cb'
 PROD_GOOGLE_CLOUD_PROJECT_NUMBER='260468725946'

--- a/src/trust/types.ts
+++ b/src/trust/types.ts
@@ -38,7 +38,7 @@ const CredentialIssuerDisplayMetadata = z.object({
 
 type ClaimsMetadata = z.infer<typeof ClaimsMetadata>;
 const ClaimsMetadata = z.object({
-  path: z.array(z.string()),
+  path: z.array(z.union([z.string(), z.number(), z.null()])), // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#name-claims-path-pointer
   display: z.array(CredentialDisplayMetadata),
 });
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Update `ClaimsMetadata` zod type

#### Motivation and Context

This PR fixes the zod type for [claims path pointer](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#appendix-C) in the Credential Issuer's Entity Configuration. The `path` property now supports strings, numbers and null values.


#### How Has This Been Tested?

Fetched the EAA Entity Configuration in `pre` and ensured the parsing succeeded.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
