### PR TITLE
chore: release `2.0.0-next.6`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-wallet",
-  "version": "2.0.0-next.5",
+  "version": "2.0.0-next.6",
   "description": "Provide data structures, helpers and API for IO Wallet",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Bump version to `2.0.0-next.6`