### PR TITLE
fix: [SIW-2859] Format type for backward-compatible status assertion

### DIFF
--- a/src/credential/presentation/07-evaluate-dcql-query.ts
+++ b/src/credential/presentation/07-evaluate-dcql-query.ts
@@ -1,10 +1,10 @@
 import { DcqlQuery, DcqlError, DcqlQueryResult } from "dcql";
 import { isValiError } from "valibot";
+import type { CryptoContext } from "@pagopa/io-react-native-jwt";
 import { decode, prepareVpToken } from "../../sd-jwt";
-import type { Disclosure } from "../../sd-jwt/types";
+import { LEGACY_SD_JWT, type Disclosure } from "../../sd-jwt/types";
 import type { RemotePresentation } from "./types";
 import { CredentialsNotFoundError, type NotFoundDetail } from "./errors";
-import type { CryptoContext } from "@pagopa/io-react-native-jwt";
 
 /**
  * The purpose for the credential request by the RP.
@@ -97,7 +97,7 @@ const extractMissingCredentials = (
     const credential = originalQuery.credentials.find((c) => c.id === id);
     if (
       credential?.format !== "dc+sd-jwt" &&
-      credential?.format !== "vc+sd-jwt"
+      credential?.format !== LEGACY_SD_JWT
     ) {
       throw new Error("Unsupported format"); // TODO [SIW-2082]: support MDOC credentials
     }
@@ -134,7 +134,7 @@ export const evaluateDcqlQuery: EvaluateDcqlQuery = (
     return getDcqlQueryMatches(queryResult).map(([id, match]) => {
       if (
         match.output.credential_format !== "dc+sd-jwt" &&
-        match.output.credential_format !== "vc+sd-jwt"
+        match.output.credential_format !== LEGACY_SD_JWT
       ) {
         throw new Error("Unsupported format"); // TODO [SIW-2082]: support MDOC credentials
       }

--- a/src/credential/status/02-status-assertion.ts
+++ b/src/credential/status/02-status-assertion.ts
@@ -15,11 +15,12 @@ import {
 } from "../../utils/errors";
 import { Logger, LogLevel } from "../../utils/logging";
 import { extractJwkFromCredential } from "../../utils/credentials";
+import type { SupportedSdJwtLegacyFormat } from "../../sd-jwt/types";
 
 export type StatusAssertion = (
   issuerConf: Out<EvaluateIssuerTrust>["issuerConf"],
   credential: Out<ObtainCredential>["credential"],
-  format: Out<ObtainCredential>["format"],
+  format: Out<ObtainCredential>["format"] | SupportedSdJwtLegacyFormat,
   context: {
     credentialCryptoContext: CryptoContext;
     wiaCryptoContext: CryptoContext;

--- a/src/credential/status/03-verify-and-parse-status-assertion.ts
+++ b/src/credential/status/03-verify-and-parse-status-assertion.ts
@@ -17,12 +17,13 @@ import { Logger, LogLevel } from "../../utils/logging";
 import type { ObtainCredential } from "../issuance";
 import { extractJwkFromCredential } from "../../utils/credentials";
 import { isSameThumbprint } from "../../utils/jwk";
+import type { SupportedSdJwtLegacyFormat } from "../../sd-jwt/types";
 
 export type VerifyAndParseStatusAssertion = (
   issuerConf: Out<EvaluateIssuerTrust>["issuerConf"],
   statusAssertion: Out<StatusAssertion>,
   credential: Out<ObtainCredential>["credential"],
-  format: Out<ObtainCredential>["format"]
+  format: Out<ObtainCredential>["format"] | SupportedSdJwtLegacyFormat
 ) => Promise<{ parsedStatusAssertion: ParsedStatusAssertion }>;
 
 /**

--- a/src/sd-jwt/types.ts
+++ b/src/sd-jwt/types.ts
@@ -21,6 +21,13 @@ export const Disclosure = z.tuple([
 ]);
 
 /**
+ * For backward compatibility reasons it is still necessary to support the legacy SD-JWT
+ * in a few flows (for instance status assertion and presentation of the old eID).
+ */
+export type SupportedSdJwtLegacyFormat = typeof LEGACY_SD_JWT;
+export const LEGACY_SD_JWT = "vc+sd-jwt";
+
+/**
  * Encoding depends on the serialization algorithm used when generating the disclosure tokens.
  * The SD-JWT reference itself take no decision about how to handle whitespaces in serialized objects.
  * For such reason, we may find conveninent to have encoded and decode values stored explicitly in the same structure.
@@ -44,7 +51,7 @@ const StatusAssertion = z.object({
 export type SdJwt4VC = z.infer<typeof SdJwt4VC>;
 export const SdJwt4VC = z.object({
   header: z.object({
-    typ: z.enum(["vc+sd-jwt", "dc+sd-jwt"]),
+    typ: z.enum(["dc+sd-jwt", LEGACY_SD_JWT]),
     alg: z.string(),
     kid: z.string(),
     trust_chain: z.array(z.string()).optional(),
@@ -62,7 +69,7 @@ export const SdJwt4VC = z.object({
         .union([
           // Credentials v1.0
           z.object({ status_assertion: StatusAssertion }),
-          // Credentials v0.7.1
+          // Legacy credentials v0.7.1
           z.object({ status_attestation: StatusAssertion }),
         ])
         .optional(),

--- a/src/trust/types.ts
+++ b/src/trust/types.ts
@@ -71,6 +71,10 @@ const SupportedCredentialMetadata = z.intersection(
   })
 );
 
+/**
+ * Supported formats for credentials issued by the Issuer API 1.0,
+ * compliant with IT-Wallet technical specifications 1.0.
+ */
 export type SupportedCredentialFormat = z.infer<
   typeof SupportedCredentialMetadata
 >["format"];

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -7,7 +7,7 @@ import { IoWalletError } from "./errors";
 import {
   LEGACY_SD_JWT,
   type SupportedSdJwtLegacyFormat,
-} from "src/sd-jwt/types";
+} from "../sd-jwt/types";
 
 const SD_JWT = ["dc+sd-jwt", LEGACY_SD_JWT];
 

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -4,8 +4,12 @@ import type { Out } from "./misc";
 import type { ObtainCredential } from "../credential/issuance";
 import type { JWK } from "./jwk";
 import { IoWalletError } from "./errors";
+import {
+  LEGACY_SD_JWT,
+  type SupportedSdJwtLegacyFormat,
+} from "src/sd-jwt/types";
 
-const SD_JWT = ["vc+sd-jwt", "dc+sd-jwt"];
+const SD_JWT = ["dc+sd-jwt", LEGACY_SD_JWT];
 
 /**
  * Extracts a JWK from a credential.
@@ -15,7 +19,7 @@ const SD_JWT = ["vc+sd-jwt", "dc+sd-jwt"];
  */
 export const extractJwkFromCredential = async (
   credential: Out<ObtainCredential>["credential"],
-  format: Out<ObtainCredential>["format"]
+  format: Out<ObtainCredential>["format"] | SupportedSdJwtLegacyFormat
 ): Promise<JWK> => {
   if (SD_JWT.includes(format)) {
     // 1. SD-JWT case


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- The status assertion functions now accept the legacy `vc+sd-jwt` as format
- The constant LEGACY_SD_JWT has been created to better distinguish the legacy format

#### Motivation and Context

For backward-compatibility reasons the status assertion functions need to work with legacy credentials. Currently the format type is extracted dynamically from the `obtainCredential`'s return type, that only encompasses the new formats.

The issue is only at the types level, as the compiled code properly handles the old format.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
