### PR TITLE
feat: [SIW-4180] Add translation fetching logic for credentials catalogue

### DIFF
--- a/example/src/screens/CredentialsCatalogue.tsx
+++ b/example/src/screens/CredentialsCatalogue.tsx
@@ -5,19 +5,28 @@ import type { TestScenarioProp } from "../components/TestScenario";
 import TestScenario from "../components/TestScenario";
 import { useDebugInfo } from "../hooks/useDebugInfo";
 import { useAppDispatch, useAppSelector } from "../store/utils";
-import { getCredentialsCatalogueThunk } from "../thunks/credentialsCatalogue";
+import {
+  getCredentialsCatalogueThunk,
+  getCredentialsCatalogueTranslationsThunk,
+} from "../thunks/credentialsCatalogue";
 import {
   selectCredentialsCatalogue,
   selectCredentialsCatalogueAsyncStatus,
+  selectCredentialsCatalogueTranslations,
+  selectCredentialsCatalogueTranslationsAsyncStatus,
 } from "../store/reducers/credentialsCatalogue";
 
 export const CredentialsCatalogueScreen = () => {
   const asyncStatus = useAppSelector(selectCredentialsCatalogueAsyncStatus);
   const credentialsCatalogue = useAppSelector(selectCredentialsCatalogue);
+  const translationsAsyncStatus = useAppSelector(
+    selectCredentialsCatalogueTranslationsAsyncStatus
+  );
+  const translations = useAppSelector(selectCredentialsCatalogueTranslations);
 
   const dispatch = useAppDispatch();
 
-  useDebugInfo({ asyncStatus, credentialsCatalogue });
+  useDebugInfo({ asyncStatus, credentialsCatalogue, translationsAsyncStatus, translations });
 
   const scenarios: Array<TestScenarioProp> = useMemo(
     () => [
@@ -33,8 +42,26 @@ export const CredentialsCatalogueScreen = () => {
         isPresent: !!credentialsCatalogue,
         successMessage: "OK",
       },
+      {
+        title: "Fetch Catalogue Translations (it)",
+        onPress: () => {
+          dispatch(getCredentialsCatalogueTranslationsThunk());
+        },
+        isLoading: translationsAsyncStatus.isLoading,
+        hasError: translationsAsyncStatus.hasError,
+        isDone: translationsAsyncStatus.isDone,
+        icon: "attachment",
+        isPresent: !!translations,
+        successMessage: `Fetched locales: ${Object.keys(translations ?? {}).join(", ") || "none"}`,
+      },
     ],
-    [dispatch, asyncStatus, credentialsCatalogue]
+    [
+      dispatch,
+      asyncStatus,
+      credentialsCatalogue,
+      translationsAsyncStatus,
+      translations,
+    ]
   );
 
   const renderItem = useCallback(

--- a/example/src/screens/CredentialsCatalogue.tsx
+++ b/example/src/screens/CredentialsCatalogue.tsx
@@ -26,7 +26,12 @@ export const CredentialsCatalogueScreen = () => {
 
   const dispatch = useAppDispatch();
 
-  useDebugInfo({ asyncStatus, credentialsCatalogue, translationsAsyncStatus, translations });
+  useDebugInfo({
+    asyncStatus,
+    credentialsCatalogue,
+    translationsAsyncStatus,
+    translations,
+  });
 
   const scenarios: Array<TestScenarioProp> = useMemo(
     () => [

--- a/example/src/store/reducers/credentialsCatalogue.ts
+++ b/example/src/store/reducers/credentialsCatalogue.ts
@@ -1,17 +1,24 @@
 import type { CredentialsCatalogue } from "@pagopa/io-react-native-wallet";
 import { createSlice } from "@reduxjs/toolkit";
-import { getCredentialsCatalogueThunk } from "../../thunks/credentialsCatalogue";
+import {
+  getCredentialsCatalogueThunk,
+  getCredentialsCatalogueTranslationsThunk,
+} from "../../thunks/credentialsCatalogue";
 import { asyncStatusInitial } from "../utils";
 import type { AsyncStatus, RootState } from "../types";
 
 type CredentialsCatalogueState = {
   catalogue: CredentialsCatalogue.DigitalCredentialsCatalogue | undefined;
+  translations: CredentialsCatalogue.CatalogueTranslations | undefined;
   asyncStatus: AsyncStatus;
+  translationsAsyncStatus: AsyncStatus;
 };
 
 const initialState: CredentialsCatalogueState = {
   catalogue: undefined,
+  translations: undefined,
   asyncStatus: asyncStatusInitial,
+  translationsAsyncStatus: asyncStatusInitial,
 };
 
 export const credentialsCatalogueSlice = createSlice({
@@ -38,6 +45,44 @@ export const credentialsCatalogueSlice = createSlice({
       state.asyncStatus.isLoading = initialState.asyncStatus.isLoading;
       state.asyncStatus.hasError = { status: true, error: action.error };
     });
+
+    builder.addCase(
+      getCredentialsCatalogueTranslationsThunk.fulfilled,
+      (state, action) => {
+        state.translations = action.payload;
+        state.translationsAsyncStatus.isDone = true;
+        state.translationsAsyncStatus.isLoading =
+          initialState.translationsAsyncStatus.isLoading;
+        state.translationsAsyncStatus.hasError =
+          initialState.translationsAsyncStatus.hasError;
+      }
+    );
+
+    builder.addCase(
+      getCredentialsCatalogueTranslationsThunk.pending,
+      (state) => {
+        state.translationsAsyncStatus.isLoading = true;
+        state.translationsAsyncStatus.isDone =
+          initialState.translationsAsyncStatus.isDone;
+        state.translationsAsyncStatus.hasError =
+          initialState.translationsAsyncStatus.hasError;
+      }
+    );
+
+    builder.addCase(
+      getCredentialsCatalogueTranslationsThunk.rejected,
+      (state, action) => {
+        state.translations = initialState.translations;
+        state.translationsAsyncStatus.isDone =
+          initialState.translationsAsyncStatus.isDone;
+        state.translationsAsyncStatus.isLoading =
+          initialState.translationsAsyncStatus.isLoading;
+        state.translationsAsyncStatus.hasError = {
+          status: true,
+          error: action.error,
+        };
+      }
+    );
   },
 });
 
@@ -46,3 +91,10 @@ export const selectCredentialsCatalogueAsyncStatus = (state: RootState) =>
 
 export const selectCredentialsCatalogue = (state: RootState) =>
   state.credentialsCatalogue.catalogue;
+
+export const selectCredentialsCatalogueTranslations = (state: RootState) =>
+  state.credentialsCatalogue.translations;
+
+export const selectCredentialsCatalogueTranslationsAsyncStatus = (
+  state: RootState
+) => state.credentialsCatalogue.translationsAsyncStatus;

--- a/example/src/thunks/credentialsCatalogue.ts
+++ b/example/src/thunks/credentialsCatalogue.ts
@@ -31,6 +31,13 @@ export const getCredentialsCatalogueTranslationsThunk = createAppAsyncThunk<
   }
 
   const wallet = new IoWallet({ version: itwVersion });
+
+  if (!wallet.CredentialsCatalogue.fetchTranslations) {
+    throw new Error(
+      "fetchTranslations is not supported by the current wallet version"
+    );
+  }
+
   return wallet.CredentialsCatalogue.fetchTranslations(
     {
       catalogue: catalogue.localization,

--- a/example/src/thunks/credentialsCatalogue.ts
+++ b/example/src/thunks/credentialsCatalogue.ts
@@ -5,6 +5,7 @@ import {
 import { selectEnv, selectItwVersion } from "../store/reducers/environment";
 import { getEnv } from "../utils/environment";
 import { createAppAsyncThunk } from "./utils";
+import { selectCredentialsCatalogue } from "../store/reducers/credentialsCatalogue";
 
 export const getCredentialsCatalogueThunk = createAppAsyncThunk<
   CredentialsCatalogue.DigitalCredentialsCatalogue,
@@ -16,4 +17,25 @@ export const getCredentialsCatalogueThunk = createAppAsyncThunk<
 
   const wallet = new IoWallet({ version: itwVersion });
   return wallet.CredentialsCatalogue.fetchAndParseCatalogue(WALLET_TA_BASE_URL);
+});
+
+export const getCredentialsCatalogueTranslationsThunk = createAppAsyncThunk<
+  CredentialsCatalogue.CatalogueTranslations,
+  void
+>("credentialsCatalogue/getTranslations", async (_, { getState }) => {
+  const itwVersion = selectItwVersion(getState());
+  const catalogue = selectCredentialsCatalogue(getState());
+
+  if (!catalogue) {
+    throw new Error("Fetch the catalogue first before fetching translations");
+  }
+
+  const wallet = new IoWallet({ version: itwVersion });
+  return wallet.CredentialsCatalogue.fetchTranslations(
+    {
+      catalogue: catalogue.localization,
+      authenticSources: catalogue.as_localization,
+    },
+    ["it"]
+  );
 });

--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -1,6 +1,20 @@
 import * as z from "zod";
 import { UnixTime } from "../../utils/zod";
 
+export const LocalizationInfo = z.object({
+  available_locales: z.array(z.string()),
+  base_uri: z.string(),
+  default_locale: z.string(),
+  version: z.string(),
+});
+export type LocalizationInfo = z.infer<typeof LocalizationInfo>;
+
+/**
+ * Merged translations for one or more locales, keyed by locale code.
+ * Each locale maps l10n_id keys to their translated string values.
+ */
+export type CatalogueTranslations = Record<string, Record<string, string>>;
+
 const AdministrativeExpirationUserInfo = z.object({
   title_l10n_id: z.string(),
   description_l10n_id: z.string(),
@@ -108,6 +122,8 @@ export const DigitalCredentialsCatalogue = z.object({
   credentials: z.array(DigitalCredential),
   iat: UnixTime,
   exp: UnixTime,
+  localization: LocalizationInfo.optional(),
+  as_localization: LocalizationInfo.optional(),
 });
 export type DigitalCredentialsCatalogue = z.infer<
   typeof DigitalCredentialsCatalogue

--- a/src/credentials-catalogue/api/index.ts
+++ b/src/credentials-catalogue/api/index.ts
@@ -1,6 +1,15 @@
-import { type DigitalCredentialsCatalogue } from "./DigitalCredentialsCatalogue";
+import {
+  type CatalogueTranslations,
+  type DigitalCredentialsCatalogue,
+  type LocalizationInfo,
+} from "./DigitalCredentialsCatalogue";
 
 type FetchContext = { appFetch?: GlobalFetch["fetch"] };
+
+type FetchTranslationsLocalizations = {
+  catalogue?: LocalizationInfo;
+  authenticSources?: LocalizationInfo;
+};
 
 export interface CredentialsCatalogueApi {
   /**
@@ -16,6 +25,29 @@ export interface CredentialsCatalogueApi {
     trustAnchorBaseUrl: string,
     ctx?: FetchContext
   ): Promise<DigitalCredentialsCatalogue>;
+
+  /**
+   * Fetch locale bundle files for the credential catalogue and authentic sources.
+   * For each requested locale, fetches translations from both registries (if the locale
+   * is listed in their respective `available_locales`) and merges the keys.
+   * Locales not present in a registry's `available_locales` are silently skipped for that source.
+   * On key conflicts, authentic-sources translations take precedence.
+   *
+   * @since 1.3.3
+   * @param localizations Localization metadata from a previously fetched catalogue
+   * @param locales Array of locale codes to fetch (e.g. ["it", "en"])
+   * @param ctx.appFetch (optional) fetch API implementation. Default: built-in fetch
+   * @returns Record keyed by locale, each containing merged translation key→value pairs
+   */
+  fetchTranslations(
+    localizations: FetchTranslationsLocalizations,
+    locales: string[],
+    ctx?: FetchContext
+  ): Promise<CatalogueTranslations>;
 }
 
-export { type DigitalCredentialsCatalogue };
+export {
+  type CatalogueTranslations,
+  type DigitalCredentialsCatalogue,
+  type LocalizationInfo,
+};

--- a/src/credentials-catalogue/api/index.ts
+++ b/src/credentials-catalogue/api/index.ts
@@ -33,13 +33,15 @@ export interface CredentialsCatalogueApi {
    * Locales not present in a registry's `available_locales` are silently skipped for that source.
    * On key conflicts, authentic-sources translations take precedence.
    *
+   * Optional: not supported by all versions. Check for existence before calling.
+   *
    * @since 1.3.3
    * @param localizations Localization metadata from a previously fetched catalogue
    * @param locales Array of locale codes to fetch (e.g. ["it", "en"])
    * @param ctx.appFetch (optional) fetch API implementation. Default: built-in fetch
    * @returns Record keyed by locale, each containing merged translation key→value pairs
    */
-  fetchTranslations(
+  fetchTranslations?(
     localizations: FetchTranslationsLocalizations,
     locales: string[],
     ctx?: FetchContext

--- a/src/credentials-catalogue/v1.0.0/index.ts
+++ b/src/credentials-catalogue/v1.0.0/index.ts
@@ -1,12 +1,6 @@
 import type { CredentialsCatalogueApi } from "../api";
 import { fetchAndParseCatalogue } from "./fetch-and-parse-catalogue";
-import { IoWalletError } from "../../utils/errors";
 
 export const CredentialsCatalogue: CredentialsCatalogueApi = {
   fetchAndParseCatalogue,
-  fetchTranslations: () => {
-    throw new IoWalletError(
-      "fetchTranslations is not supported in v1.0.0 (no localization metadata)"
-    );
-  },
 };

--- a/src/credentials-catalogue/v1.0.0/index.ts
+++ b/src/credentials-catalogue/v1.0.0/index.ts
@@ -1,6 +1,12 @@
 import type { CredentialsCatalogueApi } from "../api";
 import { fetchAndParseCatalogue } from "./fetch-and-parse-catalogue";
+import { IoWalletError } from "../../utils/errors";
 
 export const CredentialsCatalogue: CredentialsCatalogueApi = {
   fetchAndParseCatalogue,
+  fetchTranslations: () => {
+    throw new IoWalletError(
+      "fetchTranslations is not supported in v1.0.0 (no localization metadata)"
+    );
+  },
 };

--- a/src/credentials-catalogue/v1.3.3/__tests__/fetch-translations.test.ts
+++ b/src/credentials-catalogue/v1.3.3/__tests__/fetch-translations.test.ts
@@ -1,0 +1,173 @@
+import { fetchTranslations } from "../fetch-translations";
+import type { LocalizationInfo } from "../../api";
+
+const catalogueLocalization: LocalizationInfo = {
+  available_locales: ["it", "en"],
+  base_uri: "https://registry.example.it/.well-known/credential-catalog",
+  default_locale: "it",
+  version: "1.0",
+};
+
+const asLocalization: LocalizationInfo = {
+  available_locales: ["it", "en"],
+  base_uri: "https://registry.example.it/.well-known/authentic-sources",
+  default_locale: "it",
+  version: "1.0",
+};
+
+const catalogueItBundle: Record<string, string> = {
+  "mDL.name": "Patente di Guida",
+  "mDL.issuer.name": "Emittente Esempio",
+  "shared.key": "catalogue value",
+};
+
+const catalogueEnBundle: Record<string, string> = {
+  "mDL.name": "Driving Licence",
+  "mDL.issuer.name": "Example Issuer",
+  "shared.key": "catalogue value en",
+};
+
+const asItBundle: Record<string, string> = {
+  "as1.name": "Ministero Esempio",
+  "as1.dataset1.origin": "Origine Dati",
+  "shared.key": "as value",
+};
+
+const asEnBundle: Record<string, string> = {
+  "as1.name": "Example Ministry",
+  "as1.dataset1.origin": "Data Origin",
+  "shared.key": "as value en",
+};
+
+const makeFetch =
+  (bundles: Record<string, Record<string, string>>): GlobalFetch["fetch"] =>
+  (input) => {
+    const url = input.toString();
+    const bundle = bundles[url];
+    if (!bundle) {
+      return Promise.resolve({
+        status: 404,
+        headers: { get: () => null },
+        json: () => Promise.resolve(null),
+        text: () => Promise.resolve(""),
+      } as unknown as Response);
+    }
+    return Promise.resolve({
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve(bundle),
+      text: () => Promise.resolve(JSON.stringify(bundle)),
+    } as unknown as Response);
+  };
+
+describe("fetchTranslations", () => {
+  const bundleMap: Record<string, Record<string, string>> = {
+    "https://registry.example.it/.well-known/credential-catalog/it.json":
+      catalogueItBundle,
+    "https://registry.example.it/.well-known/credential-catalog/en.json":
+      catalogueEnBundle,
+    "https://registry.example.it/.well-known/authentic-sources/it.json":
+      asItBundle,
+    "https://registry.example.it/.well-known/authentic-sources/en.json":
+      asEnBundle,
+  };
+
+  it("returns merged translations for each requested locale", async () => {
+    const result = await fetchTranslations(
+      { catalogue: catalogueLocalization, authenticSources: asLocalization },
+      ["it", "en"],
+      { appFetch: makeFetch(bundleMap) }
+    );
+
+    expect(Object.keys(result)).toEqual(expect.arrayContaining(["it", "en"]));
+    expect(result.it).toMatchObject({
+      "mDL.name": "Patente di Guida",
+      "as1.name": "Ministero Esempio",
+    });
+    expect(result.en).toMatchObject({
+      "mDL.name": "Driving Licence",
+      "as1.name": "Example Ministry",
+    });
+  });
+
+  it("authentic-sources keys override catalogue keys on conflict", async () => {
+    const result = await fetchTranslations(
+      { catalogue: catalogueLocalization, authenticSources: asLocalization },
+      ["it"],
+      { appFetch: makeFetch(bundleMap) }
+    );
+
+    expect(result.it!["shared.key"]).toBe("as value");
+  });
+
+  it("skips locale silently when not in catalogue available_locales", async () => {
+    const itOnlyLocalization: LocalizationInfo = {
+      ...catalogueLocalization,
+      available_locales: ["it"],
+    };
+
+    const result = await fetchTranslations(
+      { catalogue: itOnlyLocalization, authenticSources: asLocalization },
+      ["it", "en"],
+      { appFetch: makeFetch(bundleMap) }
+    );
+
+    // "en" is not in catalogue available_locales but IS in AS → still present (from AS only)
+    expect(result.en).toBeDefined();
+    expect(result.en).not.toHaveProperty(["mDL.name"]);
+    expect(result.en!["as1.name"]).toBe("Example Ministry");
+  });
+
+  it("omits locale entirely when not in any available_locales", async () => {
+    const itOnlyLocalization: LocalizationInfo = {
+      ...catalogueLocalization,
+      available_locales: ["it"],
+    };
+    const itOnlyAsLocalization: LocalizationInfo = {
+      ...asLocalization,
+      available_locales: ["it"],
+    };
+
+    const result = await fetchTranslations(
+      {
+        catalogue: itOnlyLocalization,
+        authenticSources: itOnlyAsLocalization,
+      },
+      ["it", "en"],
+      { appFetch: makeFetch(bundleMap) }
+    );
+
+    expect(result).toHaveProperty("it");
+    expect(result).not.toHaveProperty("en");
+  });
+
+  it("works with only catalogue localization provided", async () => {
+    const result = await fetchTranslations(
+      { catalogue: catalogueLocalization },
+      ["it"],
+      { appFetch: makeFetch(bundleMap) }
+    );
+
+    expect(result.it).toMatchObject({ "mDL.name": "Patente di Guida" });
+    expect(result.it).not.toHaveProperty("as1.name");
+  });
+
+  it("works with only authenticSources localization provided", async () => {
+    const result = await fetchTranslations(
+      { authenticSources: asLocalization },
+      ["it"],
+      { appFetch: makeFetch(bundleMap) }
+    );
+
+    expect(result.it).toMatchObject({ "as1.name": "Ministero Esempio" });
+    expect(result.it).not.toHaveProperty("mDL.name");
+  });
+
+  it("returns empty object when no localizations provided", async () => {
+    const result = await fetchTranslations({}, ["it", "en"], {
+      appFetch: makeFetch(bundleMap),
+    });
+
+    expect(result).toEqual({});
+  });
+});

--- a/src/credentials-catalogue/v1.3.3/fetch-translations.ts
+++ b/src/credentials-catalogue/v1.3.3/fetch-translations.ts
@@ -1,0 +1,32 @@
+import type { CredentialsCatalogueApi as Api } from "../api";
+import { fetchLocaleBundle } from "./utils";
+
+export const fetchTranslations: Api["fetchTranslations"] = async (
+  { catalogue, authenticSources },
+  locales,
+  { appFetch = fetch } = {}
+) => {
+  const result: Record<string, Record<string, string>> = {};
+
+  await Promise.all(
+    locales.map(async (locale) => {
+      const [catalogueBundle, asBundle] = await Promise.all([
+        catalogue?.available_locales.includes(locale)
+          ? fetchLocaleBundle(catalogue.base_uri, locale, appFetch)
+          : Promise.resolve({}),
+        authenticSources?.available_locales.includes(locale)
+          ? fetchLocaleBundle(authenticSources.base_uri, locale, appFetch)
+          : Promise.resolve({}),
+      ]);
+
+      const merged = { ...catalogueBundle, ...asBundle };
+
+      // Only include the locale in the result if at least one source provided translations
+      if (Object.keys(merged).length > 0) {
+        result[locale] = merged;
+      }
+    })
+  );
+
+  return result;
+};

--- a/src/credentials-catalogue/v1.3.3/fetch-translations.ts
+++ b/src/credentials-catalogue/v1.3.3/fetch-translations.ts
@@ -1,7 +1,7 @@
 import type { CredentialsCatalogueApi as Api } from "../api";
 import { fetchLocaleBundle } from "./utils";
 
-export const fetchTranslations: Api["fetchTranslations"] = async (
+export const fetchTranslations: NonNullable<Api["fetchTranslations"]> = async (
   { catalogue, authenticSources },
   locales,
   { appFetch = fetch } = {}

--- a/src/credentials-catalogue/v1.3.3/index.ts
+++ b/src/credentials-catalogue/v1.3.3/index.ts
@@ -1,6 +1,8 @@
 import type { CredentialsCatalogueApi } from "../api";
 import { fetchAndParseCatalogue } from "./fetch-and-parse-catalogue";
+import { fetchTranslations } from "./fetch-translations";
 
 export const CredentialsCatalogue: CredentialsCatalogueApi = {
   fetchAndParseCatalogue,
+  fetchTranslations,
 };

--- a/src/credentials-catalogue/v1.3.3/mappers.ts
+++ b/src/credentials-catalogue/v1.3.3/mappers.ts
@@ -65,6 +65,8 @@ export const mapToCredentialsCatalogue = createMapper<
     return {
       ...catalogueJwt.payload,
       taxonomy_uri: discoveryJwt.payload.endpoints.taxonomy,
+      localization: catalogueJwt.payload.localization,
+      as_localization: authSourceRegistry.localization,
       credentials: catalogueJwt.payload.credentials.map(
         ({ authentic_sources, credential_name_l10n_id, ...credential }) => ({
           name_l10n_id: credential_name_l10n_id,

--- a/src/credentials-catalogue/v1.3.3/types.ts
+++ b/src/credentials-catalogue/v1.3.3/types.ts
@@ -106,8 +106,8 @@ export const DigitalCredential = z.object({
   legal_type: z.string(),
   restriction_policy: z
     .object({
-      allowed_wallet_ids: z.array(z.string()),
-      allowed_issuer_ids: z.array(z.string()),
+      allowed_wallet_ids: z.array(z.string()).optional(),
+      allowed_issuer_ids: z.array(z.string()).optional(),
       presentation_flows: z.object({
         remote: z.boolean(),
         proximity: z.boolean(),

--- a/src/credentials-catalogue/v1.3.3/utils.ts
+++ b/src/credentials-catalogue/v1.3.3/utils.ts
@@ -67,3 +67,36 @@ export const fetchRegistry = async <T>(
     `Unsupported content-type for ${url}: ${contentType}`
   );
 };
+
+/**
+ * Fetch a locale bundle file from the Registry Infrastructure.
+ * Bundle files are flat JSON objects mapping l10n_id keys to translated strings.
+ * @see https://italia.github.io/eid-wallet-it-docs/releases/1.3.3/en/registry.html
+ *
+ * @param baseUri The base URI from a registry's localization object
+ * @param locale The locale code (e.g. "it", "en")
+ * @param appFetch Custom fetch implementation
+ * @returns Flat key→value translation map
+ */
+export const fetchLocaleBundle = async (
+  baseUri: string,
+  locale: string,
+  appFetch: GlobalFetch["fetch"] = fetch
+): Promise<Record<string, string>> => {
+  const url = `${baseUri.replace(/\/$/, "")}/${locale}.json`;
+
+  const response = await appFetch(url, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  }).then(hasStatusOrThrow(200));
+
+  const contentType = response.headers.get("Content-Type");
+  if (!contentType?.includes("application/json")) {
+    throw new IoWalletError(
+      `Locale bundle at ${url} returned unexpected Content-Type: ${contentType}`
+    );
+  }
+
+  const responseJson = await response.json();
+  return z.record(z.string(), z.string()).parse(responseJson);
+};


### PR DESCRIPTION
 #### List of Changes

 - Added `fetchTranslations` to the `CredentialsCatalogueApi` interface (v1.3.3)
 - Added `LocalizationInfo` and `CatalogueTranslations` types to the shared API layer
 - Extended `DigitalCredentialsCatalogue` with optional `localization` and `as_localization` fields
 - Updated the v1.3.3 mapper to pass localization metadata through to the output
 - Added `fetchLocaleBundle` utility to fetch locale bundle JSON files from the registry
 - Fixed `restriction_policy.allowed_wallet_ids` and `allowed_issuer_ids` to be optional in the v1.3.3 schema
 - Added example app support: thunk, reducer state, and a new button in the Credentials Catalogue screen

 #### Motivation and Context

 The IT-Wallet registry (v1.3.3) exposes localization metadata in both the credential catalogue and
 the authentic sources registry. These point to locale bundle files (flat key→value JSON) that
 resolve the `_l10n_id` keys used throughout the catalogue into human-readable strings.

 This change adds the ability to fetch and merge those bundles for one or more locales, returning
 a single `Record<locale, Record<key, string>>` object ready for use in the UI.

 #### How Has This Been Tested?

 - Unit tests cover the main behaviors: merged output per locale, AS keys winning on conflict,
   silently skipping locales not in `available_locales`, and graceful handling of missing
   localization metadata
 - Manually tested against the pre environment via the example app

 #### Screenshots (if appropriate):

 #### Checklist:

 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.