### PR TITLE
feat: [SIW-4216] Implement taxonomy registry fetching and translations

### DIFF
--- a/example/src/thunks/credentialsCatalogue.ts
+++ b/example/src/thunks/credentialsCatalogue.ts
@@ -42,6 +42,7 @@ export const getCredentialsCatalogueTranslationsThunk = createAppAsyncThunk<
     {
       catalogue: catalogue.localization,
       authenticSources: catalogue.as_localization,
+      taxonomy: catalogue.taxonomy?.localization,
     },
     ["it"]
   );

--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -120,15 +120,21 @@ export const DigitalCredential = z.object({
 const TaxonomyPurpose = z.object({
   id: z.string(),
   name_l10n_id: z.string(),
-  description_l10n_id: z.string(),
 });
 export type TaxonomyPurpose = z.infer<typeof TaxonomyPurpose>;
+
+const TaxonomyClass = z.object({
+  id: z.string(),
+  name_l10n_id: z.string(),
+  supported_purposes: z.array(z.string()),
+});
+export type TaxonomyClass = z.infer<typeof TaxonomyClass>;
 
 const TaxonomyDomain = z.object({
   id: z.string(),
   name_l10n_id: z.string(),
   description_l10n_id: z.string(),
-  purposes: z.array(TaxonomyPurpose).optional(),
+  classes: z.array(TaxonomyClass),
 });
 export type TaxonomyDomain = z.infer<typeof TaxonomyDomain>;
 
@@ -137,6 +143,7 @@ export const Taxonomy = z.object({
   name_l10n_id: z.string(),
   description_l10n_id: z.string(),
   domains: z.array(TaxonomyDomain),
+  purposes: z.array(TaxonomyPurpose),
   localization: LocalizationInfo.optional(),
 });
 export type Taxonomy = z.infer<typeof Taxonomy>;

--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -117,8 +117,33 @@ export const DigitalCredential = z.object({
   // claims: z.array(Claim), // TODO: [SIW-3978] Should we keep claims?
 });
 
+const TaxonomyPurpose = z.object({
+  id: z.string(),
+  name_l10n_id: z.string(),
+  description_l10n_id: z.string(),
+});
+export type TaxonomyPurpose = z.infer<typeof TaxonomyPurpose>;
+
+const TaxonomyDomain = z.object({
+  id: z.string(),
+  name_l10n_id: z.string(),
+  description_l10n_id: z.string(),
+  purposes: z.array(TaxonomyPurpose),
+});
+export type TaxonomyDomain = z.infer<typeof TaxonomyDomain>;
+
+export const Taxonomy = z.object({
+  id: z.string(),
+  name_l10n_id: z.string(),
+  description_l10n_id: z.string(),
+  domains: z.array(TaxonomyDomain),
+  localization: LocalizationInfo.optional(),
+});
+export type Taxonomy = z.infer<typeof Taxonomy>;
+
 export const DigitalCredentialsCatalogue = z.object({
   taxonomy_uri: z.string().url(),
+  taxonomy: Taxonomy.optional(),
   credentials: z.array(DigitalCredential),
   iat: UnixTime,
   exp: UnixTime,

--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -128,7 +128,7 @@ const TaxonomyDomain = z.object({
   id: z.string(),
   name_l10n_id: z.string(),
   description_l10n_id: z.string(),
-  purposes: z.array(TaxonomyPurpose),
+  purposes: z.array(TaxonomyPurpose).optional(),
 });
 export type TaxonomyDomain = z.infer<typeof TaxonomyDomain>;
 

--- a/src/credentials-catalogue/api/index.ts
+++ b/src/credentials-catalogue/api/index.ts
@@ -2,6 +2,7 @@ import {
   type CatalogueTranslations,
   type DigitalCredentialsCatalogue,
   type LocalizationInfo,
+  type Taxonomy,
 } from "./DigitalCredentialsCatalogue";
 
 type FetchContext = { appFetch?: GlobalFetch["fetch"] };
@@ -9,6 +10,7 @@ type FetchContext = { appFetch?: GlobalFetch["fetch"] };
 type FetchTranslationsLocalizations = {
   catalogue?: LocalizationInfo;
   authenticSources?: LocalizationInfo;
+  taxonomy?: LocalizationInfo;
 };
 
 export interface CredentialsCatalogueApi {
@@ -27,11 +29,11 @@ export interface CredentialsCatalogueApi {
   ): Promise<DigitalCredentialsCatalogue>;
 
   /**
-   * Fetch locale bundle files for the credential catalogue and authentic sources.
-   * For each requested locale, fetches translations from both registries (if the locale
+   * Fetch locale bundle files for the credential catalogue, authentic sources, and taxonomy.
+   * For each requested locale, fetches translations from all registries (if the locale
    * is listed in their respective `available_locales`) and merges the keys.
    * Locales not present in a registry's `available_locales` are silently skipped for that source.
-   * On key conflicts, authentic-sources translations take precedence.
+   * On key conflicts, later sources (authenticSources, taxonomy) take precedence.
    *
    * Optional: not supported by all versions. Check for existence before calling.
    *
@@ -52,4 +54,5 @@ export {
   type CatalogueTranslations,
   type DigitalCredentialsCatalogue,
   type LocalizationInfo,
+  type Taxonomy,
 };

--- a/src/credentials-catalogue/v1.3.3/__tests__/fetch-translations.test.ts
+++ b/src/credentials-catalogue/v1.3.3/__tests__/fetch-translations.test.ts
@@ -15,6 +15,13 @@ const asLocalization: LocalizationInfo = {
   version: "1.0",
 };
 
+const taxonomyLocalization: LocalizationInfo = {
+  available_locales: ["it", "en"],
+  base_uri: "https://registry.example.it/.well-known/l10n/taxonomy",
+  default_locale: "it",
+  version: "1.0",
+};
+
 const catalogueItBundle: Record<string, string> = {
   "mDL.name": "Patente di Guida",
   "mDL.issuer.name": "Emittente Esempio",
@@ -37,6 +44,18 @@ const asEnBundle: Record<string, string> = {
   "as1.name": "Example Ministry",
   "as1.dataset1.origin": "Data Origin",
   "shared.key": "as value en",
+};
+
+const taxonomyItBundle: Record<string, string> = {
+  "taxonomy.name": "Tassonomia IT-Wallet",
+  "domain.identity.name": "Identità",
+  "purpose.person_identification.name": "Identificazione Persona",
+};
+
+const taxonomyEnBundle: Record<string, string> = {
+  "taxonomy.name": "IT-Wallet Taxonomy",
+  "domain.identity.name": "Identity",
+  "purpose.person_identification.name": "Person Identification",
 };
 
 const makeFetch =
@@ -70,6 +89,10 @@ describe("fetchTranslations", () => {
       asItBundle,
     "https://registry.example.it/.well-known/authentic-sources/en.json":
       asEnBundle,
+    "https://registry.example.it/.well-known/l10n/taxonomy/it.json":
+      taxonomyItBundle,
+    "https://registry.example.it/.well-known/l10n/taxonomy/en.json":
+      taxonomyEnBundle,
   };
 
   it("returns merged translations for each requested locale", async () => {
@@ -127,11 +150,16 @@ describe("fetchTranslations", () => {
       ...asLocalization,
       available_locales: ["it"],
     };
+    const itOnlyTaxonomyLocalization: LocalizationInfo = {
+      ...taxonomyLocalization,
+      available_locales: ["it"],
+    };
 
     const result = await fetchTranslations(
       {
         catalogue: itOnlyLocalization,
         authenticSources: itOnlyAsLocalization,
+        taxonomy: itOnlyTaxonomyLocalization,
       },
       ["it", "en"],
       { appFetch: makeFetch(bundleMap) }
@@ -169,5 +197,79 @@ describe("fetchTranslations", () => {
     });
 
     expect(result).toEqual({});
+  });
+
+  it("includes taxonomy translations when taxonomy localization is provided", async () => {
+    const result = await fetchTranslations(
+      {
+        catalogue: catalogueLocalization,
+        authenticSources: asLocalization,
+        taxonomy: taxonomyLocalization,
+      },
+      ["it"],
+      { appFetch: makeFetch(bundleMap) }
+    );
+
+    expect(result.it).toMatchObject({
+      "mDL.name": "Patente di Guida",
+      "as1.name": "Ministero Esempio",
+      "taxonomy.name": "Tassonomia IT-Wallet",
+      "domain.identity.name": "Identità",
+      "purpose.person_identification.name": "Identificazione Persona",
+    });
+  });
+
+  it("works with only taxonomy localization provided", async () => {
+    const result = await fetchTranslations(
+      { taxonomy: taxonomyLocalization },
+      ["it", "en"],
+      { appFetch: makeFetch(bundleMap) }
+    );
+
+    expect(result.it).toMatchObject({
+      "taxonomy.name": "Tassonomia IT-Wallet",
+      "domain.identity.name": "Identità",
+    });
+    expect(result.en).toMatchObject({
+      "taxonomy.name": "IT-Wallet Taxonomy",
+      "domain.identity.name": "Identity",
+    });
+    expect(result.it).not.toHaveProperty("mDL.name");
+    expect(result.it).not.toHaveProperty("as1.name");
+  });
+
+  it("taxonomy keys take precedence over catalogue and AS keys on conflict", async () => {
+    const catalogueWithConflict: LocalizationInfo = {
+      ...catalogueLocalization,
+      available_locales: ["it"],
+    };
+    const taxonomyWithConflict: LocalizationInfo = {
+      ...taxonomyLocalization,
+      available_locales: ["it"],
+    };
+
+    // Add a conflicting key via a custom bundle map
+    const conflictBundleMap: Record<string, Record<string, string>> = {
+      ...bundleMap,
+      "https://registry.example.it/.well-known/credential-catalog/it.json": {
+        ...catalogueItBundle,
+        "conflict.key": "from catalogue",
+      },
+      "https://registry.example.it/.well-known/l10n/taxonomy/it.json": {
+        ...taxonomyItBundle,
+        "conflict.key": "from taxonomy",
+      },
+    };
+
+    const result = await fetchTranslations(
+      {
+        catalogue: catalogueWithConflict,
+        taxonomy: taxonomyWithConflict,
+      },
+      ["it"],
+      { appFetch: makeFetch(conflictBundleMap) }
+    );
+
+    expect(result.it!["conflict.key"]).toBe("from taxonomy");
   });
 });

--- a/src/credentials-catalogue/v1.3.3/__tests__/mappers.test.ts
+++ b/src/credentials-catalogue/v1.3.3/__tests__/mappers.test.ts
@@ -5,6 +5,7 @@ import type {
   DigitalCredentialsCatalogueJwt,
   RegistryDiscoveryJwt,
   SchemaRegistry,
+  TaxonomyRegistry,
 } from "../types";
 
 describe("mapToCredentialsCatalogue", () => {
@@ -57,6 +58,47 @@ describe("mapToCredentialsCatalogue", () => {
           policy_uri: "https://source-org.example.com/privacy",
         },
         data_capabilities: [],
+      },
+    ],
+  };
+
+  const taxonomyRegistry: TaxonomyRegistry = {
+    version: "1.0",
+    last_modified: "2025-04-10T12:00:00Z",
+    id: "urn:taxonomy:it-wallet",
+    localization: {
+      default_locale: "it",
+      available_locales: ["it", "en"],
+      base_uri:
+        "https://trust-registry.eid-wallet.example.it/.well-known/l10n/taxonomy/",
+      version: "1.0.0",
+    },
+    name_l10n_id: "taxonomy.name",
+    description_l10n_id: "taxonomy.description",
+    domains: [
+      {
+        id: "IDENTITY",
+        name_l10n_id: "domain.identity.name",
+        description_l10n_id: "domain.identity.description",
+        purposes: [
+          {
+            id: "PERSON_IDENTIFICATION",
+            name_l10n_id: "purpose.person_identification.name",
+            description_l10n_id: "purpose.person_identification.description",
+          },
+        ],
+      },
+      {
+        id: "AUTHORIZATION",
+        name_l10n_id: "domain.authorization.name",
+        description_l10n_id: "domain.authorization.description",
+        purposes: [
+          {
+            id: "DRIVING_LICENSE",
+            name_l10n_id: "purpose.driving_license.name",
+            description_l10n_id: "purpose.driving_license.description",
+          },
+        ],
       },
     ],
   };
@@ -118,6 +160,45 @@ describe("mapToCredentialsCatalogue", () => {
 
   const expected: DigitalCredentialsCatalogue = {
     taxonomy_uri: "https://issuer-example.com/taxonomy.json",
+    taxonomy: {
+      id: "urn:taxonomy:it-wallet",
+      name_l10n_id: "taxonomy.name",
+      description_l10n_id: "taxonomy.description",
+      localization: {
+        default_locale: "it",
+        available_locales: ["it", "en"],
+        base_uri:
+          "https://trust-registry.eid-wallet.example.it/.well-known/l10n/taxonomy/",
+        version: "1.0.0",
+      },
+      domains: [
+        {
+          id: "IDENTITY",
+          name_l10n_id: "domain.identity.name",
+          description_l10n_id: "domain.identity.description",
+          purposes: [
+            {
+              id: "PERSON_IDENTIFICATION",
+              name_l10n_id: "purpose.person_identification.name",
+              description_l10n_id:
+                "purpose.person_identification.description",
+            },
+          ],
+        },
+        {
+          id: "AUTHORIZATION",
+          name_l10n_id: "domain.authorization.name",
+          description_l10n_id: "domain.authorization.description",
+          purposes: [
+            {
+              id: "DRIVING_LICENSE",
+              name_l10n_id: "purpose.driving_license.name",
+              description_l10n_id: "purpose.driving_license.description",
+            },
+          ],
+        },
+      ],
+    },
     iat: 1730000000,
     exp: 1730003600,
     credentials: [
@@ -178,6 +259,7 @@ describe("mapToCredentialsCatalogue", () => {
         credentialsCatalogueJwt,
         authSourceRegistry,
         schemaRegistry,
+        taxonomyRegistry,
       ])
     ).toEqual(expected);
   });

--- a/src/credentials-catalogue/v1.3.3/__tests__/mappers.test.ts
+++ b/src/credentials-catalogue/v1.3.3/__tests__/mappers.test.ts
@@ -63,8 +63,8 @@ describe("mapToCredentialsCatalogue", () => {
   };
 
   const taxonomyRegistry: TaxonomyRegistry = {
-    version: "1.0",
-    last_modified: "2025-04-10T12:00:00Z",
+    version: "1.0.0",
+    last_modified: "2026-03-11T00:00:00Z",
     id: "urn:taxonomy:it-wallet",
     localization: {
       default_locale: "it",
@@ -80,11 +80,14 @@ describe("mapToCredentialsCatalogue", () => {
         id: "IDENTITY",
         name_l10n_id: "domain.identity.name",
         description_l10n_id: "domain.identity.description",
-        purposes: [
+        classes: [
           {
-            id: "PERSON_IDENTIFICATION",
-            name_l10n_id: "purpose.person_identification.name",
-            description_l10n_id: "purpose.person_identification.description",
+            id: "IDENTIFICATION_DOCUMENTS",
+            name_l10n_id: "class.identification_documents.name",
+            supported_purposes: [
+              "IDENTITY_VERIFICATION",
+              "PERSON_IDENTIFICATION",
+            ],
           },
         ],
       },
@@ -92,13 +95,27 @@ describe("mapToCredentialsCatalogue", () => {
         id: "AUTHORIZATION",
         name_l10n_id: "domain.authorization.name",
         description_l10n_id: "domain.authorization.description",
-        purposes: [
+        classes: [
           {
-            id: "DRIVING_LICENSE",
-            name_l10n_id: "purpose.driving_license.name",
-            description_l10n_id: "purpose.driving_license.description",
+            id: "LICENSES_AUTHORIZATIONS",
+            name_l10n_id: "class.licenses_authorizations.name",
+            supported_purposes: ["DRIVING_RIGHTS_VERIFICATION"],
           },
         ],
+      },
+    ],
+    purposes: [
+      {
+        id: "IDENTITY_VERIFICATION",
+        name_l10n_id: "purpose.identity_verification.name",
+      },
+      {
+        id: "PERSON_IDENTIFICATION",
+        name_l10n_id: "purpose.person_identification.name",
+      },
+      {
+        id: "DRIVING_RIGHTS_VERIFICATION",
+        name_l10n_id: "purpose.driving_rights_verification.name",
       },
     ],
   };
@@ -176,12 +193,14 @@ describe("mapToCredentialsCatalogue", () => {
           id: "IDENTITY",
           name_l10n_id: "domain.identity.name",
           description_l10n_id: "domain.identity.description",
-          purposes: [
+          classes: [
             {
-              id: "PERSON_IDENTIFICATION",
-              name_l10n_id: "purpose.person_identification.name",
-              description_l10n_id:
-                "purpose.person_identification.description",
+              id: "IDENTIFICATION_DOCUMENTS",
+              name_l10n_id: "class.identification_documents.name",
+              supported_purposes: [
+                "IDENTITY_VERIFICATION",
+                "PERSON_IDENTIFICATION",
+              ],
             },
           ],
         },
@@ -189,13 +208,27 @@ describe("mapToCredentialsCatalogue", () => {
           id: "AUTHORIZATION",
           name_l10n_id: "domain.authorization.name",
           description_l10n_id: "domain.authorization.description",
-          purposes: [
+          classes: [
             {
-              id: "DRIVING_LICENSE",
-              name_l10n_id: "purpose.driving_license.name",
-              description_l10n_id: "purpose.driving_license.description",
+              id: "LICENSES_AUTHORIZATIONS",
+              name_l10n_id: "class.licenses_authorizations.name",
+              supported_purposes: ["DRIVING_RIGHTS_VERIFICATION"],
             },
           ],
+        },
+      ],
+      purposes: [
+        {
+          id: "IDENTITY_VERIFICATION",
+          name_l10n_id: "purpose.identity_verification.name",
+        },
+        {
+          id: "PERSON_IDENTIFICATION",
+          name_l10n_id: "purpose.person_identification.name",
+        },
+        {
+          id: "DRIVING_RIGHTS_VERIFICATION",
+          name_l10n_id: "purpose.driving_rights_verification.name",
         },
       ],
     },

--- a/src/credentials-catalogue/v1.3.3/fetch-and-parse-catalogue.ts
+++ b/src/credentials-catalogue/v1.3.3/fetch-and-parse-catalogue.ts
@@ -5,6 +5,7 @@ import {
   DigitalCredentialsCatalogueJwt,
   RegistryDiscoveryJwt,
   SchemaRegistry,
+  TaxonomyRegistry,
 } from "./types";
 import { mapToCredentialsCatalogue } from "./mappers";
 import { fetchRegistry } from "./utils";
@@ -43,6 +44,11 @@ export const fetchAndParseCatalogue: Api["fetchAndParseCatalogue"] = async (
     }),
     fetchRegistry(endpoints.schema_registry, {
       schema: SchemaRegistry,
+      asJson: true,
+      appFetch,
+    }),
+    fetchRegistry(endpoints.taxonomy, {
+      schema: TaxonomyRegistry,
       asJson: true,
       appFetch,
     }),

--- a/src/credentials-catalogue/v1.3.3/fetch-translations.ts
+++ b/src/credentials-catalogue/v1.3.3/fetch-translations.ts
@@ -2,7 +2,7 @@ import type { CredentialsCatalogueApi as Api } from "../api";
 import { fetchLocaleBundle } from "./utils";
 
 export const fetchTranslations: NonNullable<Api["fetchTranslations"]> = async (
-  { catalogue, authenticSources },
+  { catalogue, authenticSources, taxonomy },
   locales,
   { appFetch = fetch } = {}
 ) => {
@@ -10,16 +10,19 @@ export const fetchTranslations: NonNullable<Api["fetchTranslations"]> = async (
 
   await Promise.all(
     locales.map(async (locale) => {
-      const [catalogueBundle, asBundle] = await Promise.all([
+      const [catalogueBundle, asBundle, taxonomyBundle] = await Promise.all([
         catalogue?.available_locales.includes(locale)
           ? fetchLocaleBundle(catalogue.base_uri, locale, appFetch)
           : Promise.resolve({}),
         authenticSources?.available_locales.includes(locale)
           ? fetchLocaleBundle(authenticSources.base_uri, locale, appFetch)
           : Promise.resolve({}),
+        taxonomy?.available_locales.includes(locale)
+          ? fetchLocaleBundle(taxonomy.base_uri, locale, appFetch)
+          : Promise.resolve({}),
       ]);
 
-      const merged = { ...catalogueBundle, ...asBundle };
+      const merged = { ...catalogueBundle, ...asBundle, ...taxonomyBundle };
 
       // Only include the locale in the result if at least one source provided translations
       if (Object.keys(merged).length > 0) {

--- a/src/credentials-catalogue/v1.3.3/mappers.ts
+++ b/src/credentials-catalogue/v1.3.3/mappers.ts
@@ -78,6 +78,7 @@ export const mapToCredentialsCatalogue = createMapper<
         name_l10n_id: taxonomyRegistry.name_l10n_id,
         description_l10n_id: taxonomyRegistry.description_l10n_id,
         domains: taxonomyRegistry.domains,
+        purposes: taxonomyRegistry.purposes,
         localization: taxonomyRegistry.localization,
       },
       localization: catalogueJwt.payload.localization,

--- a/src/credentials-catalogue/v1.3.3/mappers.ts
+++ b/src/credentials-catalogue/v1.3.3/mappers.ts
@@ -11,6 +11,7 @@ import {
   DigitalCredentialsCatalogueJwt,
   RegistryDiscoveryJwt,
   SchemaRegistry,
+  TaxonomyRegistry,
 } from "./types";
 
 export const mapToCredentialsCatalogue = createMapper<
@@ -19,10 +20,17 @@ export const mapToCredentialsCatalogue = createMapper<
     DigitalCredentialsCatalogueJwt,
     AuthenticSourceRegistry,
     SchemaRegistry,
+    TaxonomyRegistry,
   ],
   DigitalCredentialsCatalogue
 >(
-  ([discoveryJwt, catalogueJwt, authSourceRegistry, schemaRegistry]) => {
+  ([
+    discoveryJwt,
+    catalogueJwt,
+    authSourceRegistry,
+    schemaRegistry,
+    taxonomyRegistry,
+  ]) => {
     const authSourcesById = keyBy(
       authSourceRegistry.authentic_sources,
       "entity_id"
@@ -65,6 +73,13 @@ export const mapToCredentialsCatalogue = createMapper<
     return {
       ...catalogueJwt.payload,
       taxonomy_uri: discoveryJwt.payload.endpoints.taxonomy,
+      taxonomy: {
+        id: taxonomyRegistry.id,
+        name_l10n_id: taxonomyRegistry.name_l10n_id,
+        description_l10n_id: taxonomyRegistry.description_l10n_id,
+        domains: taxonomyRegistry.domains,
+        localization: taxonomyRegistry.localization,
+      },
       localization: catalogueJwt.payload.localization,
       as_localization: authSourceRegistry.localization,
       credentials: catalogueJwt.payload.credentials.map(

--- a/src/credentials-catalogue/v1.3.3/types.ts
+++ b/src/credentials-catalogue/v1.3.3/types.ts
@@ -250,7 +250,7 @@ const TaxonomyDomain = z.object({
   id: z.string(),
   name_l10n_id: z.string(),
   description_l10n_id: z.string(),
-  purposes: z.array(TaxonomyPurpose),
+  purposes: z.array(TaxonomyPurpose).optional(),
 });
 
 /**

--- a/src/credentials-catalogue/v1.3.3/types.ts
+++ b/src/credentials-catalogue/v1.3.3/types.ts
@@ -235,27 +235,35 @@ export const RegistryDiscoveryJwt = z.object({
 export type RegistryDiscoveryJwt = z.infer<typeof RegistryDiscoveryJwt>;
 
 /**
- * Taxonomy purpose within a domain.
+ * Taxonomy purpose (top-level flat list).
  */
 const TaxonomyPurpose = z.object({
   id: z.string(),
   name_l10n_id: z.string(),
-  description_l10n_id: z.string(),
 });
 
 /**
- * Taxonomy domain containing purposes.
+ * Taxonomy class within a domain.
+ */
+const TaxonomyClass = z.object({
+  id: z.string(),
+  name_l10n_id: z.string(),
+  supported_purposes: z.array(z.string()),
+});
+
+/**
+ * Taxonomy domain containing classes.
  */
 const TaxonomyDomain = z.object({
   id: z.string(),
   name_l10n_id: z.string(),
   description_l10n_id: z.string(),
-  purposes: z.array(TaxonomyPurpose).optional(),
+  classes: z.array(TaxonomyClass),
 });
 
 /**
  * Taxonomy registry, available at a dedicated endpoint.
- * Provides a hierarchical classification of domains and purposes.
+ * Provides a hierarchical classification of domains, classes, and purposes.
  * @see https://italia.github.io/eid-wallet-it-docs/releases/1.3.3/en/registry.html#taxonomy
  */
 export const TaxonomyRegistry = z.object({
@@ -273,5 +281,6 @@ export const TaxonomyRegistry = z.object({
   name_l10n_id: z.string(),
   description_l10n_id: z.string(),
   domains: z.array(TaxonomyDomain),
+  purposes: z.array(TaxonomyPurpose),
 });
 export type TaxonomyRegistry = z.infer<typeof TaxonomyRegistry>;

--- a/src/credentials-catalogue/v1.3.3/types.ts
+++ b/src/credentials-catalogue/v1.3.3/types.ts
@@ -233,3 +233,45 @@ export const RegistryDiscoveryJwt = z.object({
   }),
 });
 export type RegistryDiscoveryJwt = z.infer<typeof RegistryDiscoveryJwt>;
+
+/**
+ * Taxonomy purpose within a domain.
+ */
+const TaxonomyPurpose = z.object({
+  id: z.string(),
+  name_l10n_id: z.string(),
+  description_l10n_id: z.string(),
+});
+
+/**
+ * Taxonomy domain containing purposes.
+ */
+const TaxonomyDomain = z.object({
+  id: z.string(),
+  name_l10n_id: z.string(),
+  description_l10n_id: z.string(),
+  purposes: z.array(TaxonomyPurpose),
+});
+
+/**
+ * Taxonomy registry, available at a dedicated endpoint.
+ * Provides a hierarchical classification of domains and purposes.
+ * @see https://italia.github.io/eid-wallet-it-docs/releases/1.3.3/en/registry.html#taxonomy
+ */
+export const TaxonomyRegistry = z.object({
+  version: z.string(),
+  last_modified: z.string(),
+  id: z.string(),
+  localization: z
+    .object({
+      available_locales: z.array(z.string()),
+      base_uri: z.string(),
+      default_locale: z.string(),
+      version: z.string(),
+    })
+    .optional(),
+  name_l10n_id: z.string(),
+  description_l10n_id: z.string(),
+  domains: z.array(TaxonomyDomain),
+});
+export type TaxonomyRegistry = z.infer<typeof TaxonomyRegistry>;


### PR DESCRIPTION
#### List of Changes

- Add `TaxonomyRegistry` Zod schema in `v1.3.3/types.ts` (domains → classes → supported_purposes, flat purposes array)
- Add `Taxonomy`, `TaxonomyDomain`, `TaxonomyClass`, `TaxonomyPurpose` types to the public API
- Fetch taxonomy endpoint (as JSON) alongside other registries in `fetch-and-parse-catalogue.ts`
- Include taxonomy data in the mapped catalogue output
- Support taxonomy localization in `fetchTranslations` (taxonomy keys take highest precedence)
- Add `taxonomy` field to `FetchTranslationsLocalizations` in the API interface

#### Motivation and Context

The IT-Wallet specification requires taxonomy support for hierarchical classification of credentials by domain, class, and purpose. The taxonomy is fetched from the registry discovery endpoint and provides localized labels.

Reference: https://italia.github.io/eid-wallet-it-docs/releases/1.3.3/en/registry.html#taxonomy

#### How Has This Been Tested?

- Fetch credential catalogue and translations in the example app
- Verify the catalogue and translations contains taxonomy data

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.