### PR TITLE
chore: [SIW-0000] Drop evidence from verification claim

### DIFF
--- a/src/sd-jwt/__test__/types.test.ts
+++ b/src/sd-jwt/__test__/types.test.ts
@@ -28,20 +28,8 @@ describe("Verification.time", () => {
 
   it("rejects invalid type", () => {
     const value = {
-      trust_framework: "eidas",
+      trust_framework: ["eidas"],
       assurance_level: "high",
-      evidence: [
-        {
-          type: "vouch",
-          time: null,
-          attestation: {
-            type: "digital_attestation",
-            reference_number: "abc",
-            date_of_issuance: "2025-09-02",
-            voucher: { organization: "IPZS" },
-          },
-        },
-      ],
     };
 
     expect(Verification.safeParse(value).success).toBe(false);

--- a/src/sd-jwt/__test__/utils.test.ts
+++ b/src/sd-jwt/__test__/utils.test.ts
@@ -4,18 +4,6 @@ import { getVerification } from "..";
 describe("SD-JWT getVerification", () => {
   it("extracts the verification claims correctly", () => {
     expect(getVerification(pid)).toEqual({
-      evidence: [
-        {
-          attestation: {
-            date_of_issuance: "2025-06-23",
-            voucher: { organization: "Ministero dell'Interno" },
-            type: "digital_attestation",
-            reference_number: "123456789",
-          },
-          time: "2025-06-23T13:14:25Z",
-          type: "vouch",
-        },
-      ],
       trust_framework: "it_cie",
       assurance_level: "high",
     });

--- a/src/sd-jwt/types.ts
+++ b/src/sd-jwt/types.ts
@@ -64,19 +64,6 @@ export type Verification = z.infer<typeof Verification>;
 export const Verification = z.object({
   trust_framework: z.string(),
   assurance_level: z.string(),
-  evidence: z.array(
-    z.object({
-      type: z.literal("vouch"),
-      // Support both string and UNIX timestamp for backward compatibility
-      time: z.union([z.string(), z.number()]),
-      attestation: z.object({
-        type: z.literal("digital_attestation"),
-        reference_number: z.string(),
-        date_of_issuance: z.string(),
-        voucher: z.object({ organization: z.string() }),
-      }),
-    })
-  ),
 });
 
 /**


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

This PR removes `evidence` from the verification claim in SD-JWTs. The new shape needs to match `{ "trust_framework": "",  "assurance_level": "" }`, so the previous shape still passes validation.

> [!warning]
> The PR may introduce a breaking change if evidence was used.

#### How Has This Been Tested?

No regressions introduced in the 1.0 issuance flow.
