### PR TITLE
feat: [SIW-4335] add getStatusL10nIds utility

### DIFF
--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -1,11 +1,6 @@
 import * as z from "zod";
 import { UnixTime } from "../../utils/zod";
 
-export type GetStatusL10nIds = (
-  statusBit: string,
-  credentialConfig: DigitalCredential
-) => { titleL10nId: string; descriptionL10nId: string } | undefined;
-
 export const LocalizationInfo = z.object({
   available_locales: z.array(z.string()),
   base_uri: z.string(),

--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -27,7 +27,6 @@ const AllowedState = z
   })
   .catchall(z.string());
 
-
 /**
  * Given a statusBit (e.g. "0x00", "0x0B") and a DigitalCredential from the
  * catalogue, returns the matching l10n IDs or undefined if not found.

--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -1,6 +1,11 @@
 import * as z from "zod";
 import { UnixTime } from "../../utils/zod";
 
+export type GetStatusL10nIds = (
+  statusBit: string,
+  credentialConfig: DigitalCredential
+) => { titleL10nId: string; descriptionL10nId: string } | undefined;
+
 export const LocalizationInfo = z.object({
   available_locales: z.array(z.string()),
   base_uri: z.string(),
@@ -20,35 +25,14 @@ const AdministrativeExpirationUserInfo = z.object({
   description_l10n_id: z.string(),
 });
 
-const AllowedState = z
+export const AllowedState = z
   .object({
     title_l10n_id: z.string(),
     description_l10n_id: z.string(),
   })
   .catchall(z.string());
-
-/**
- * Given a statusBit (e.g. "0x00", "0x0B") and a DigitalCredential from the
- * catalogue, returns the matching l10n IDs or undefined if not found.
- * The comparison is case-insensitive to handle uppercase statusBit values
- * returned by verifyAndParseStatusList against lowercase keys in the catalogue.
- */
-export const getStatusL10nIds = (
-  statusBit: string,
-  credentialConfig: DigitalCredential
-): { titleL10nId: string; descriptionL10nId: string } | undefined => {
-  const normalizedBit = statusBit.toLowerCase();
-  const match = credentialConfig.validity_info.allowed_states.find(
-    (s): s is z.infer<typeof AllowedState> =>
-      typeof s === "object" &&
-      Object.keys(s).some((k) => k.toLowerCase() === normalizedBit)
-  );
-  if (!match) return undefined;
-  return {
-    titleL10nId: match.title_l10n_id,
-    descriptionL10nId: match.description_l10n_id,
-  };
-};
+  
+export type AllowedState = z.infer<typeof AllowedState>;
 
 const CredentialPurpose = z.object({
   id: z.string(),

--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -31,7 +31,7 @@ export const AllowedState = z
     description_l10n_id: z.string(),
   })
   .catchall(z.string());
-  
+
 export type AllowedState = z.infer<typeof AllowedState>;
 
 const CredentialPurpose = z.object({

--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -27,21 +27,20 @@ const AllowedState = z
   })
   .catchall(z.string());
 
-export type AllowedState = z.infer<typeof AllowedState>;
 
 /**
- * Given a statusBit (e.g. "0x00", "0x0B") and the allowed_states array
- * from the catalogue, returns the matching l10n IDs or undefined if not found.
+ * Given a statusBit (e.g. "0x00", "0x0B") and a DigitalCredential from the
+ * catalogue, returns the matching l10n IDs or undefined if not found.
  * The comparison is case-insensitive to handle uppercase statusBit values
  * returned by verifyAndParseStatusList against lowercase keys in the catalogue.
  */
 export const getStatusL10nIds = (
   statusBit: string,
-  allowedStates: Array<string | AllowedState>
+  credentialConfig: DigitalCredential
 ): { titleL10nId: string; descriptionL10nId: string } | undefined => {
   const normalizedBit = statusBit.toLowerCase();
-  const match = allowedStates.find(
-    (s): s is AllowedState =>
+  const match = credentialConfig.validity_info.allowed_states.find(
+    (s): s is z.infer<typeof AllowedState> =>
       typeof s === "object" &&
       Object.keys(s).some((k) => k.toLowerCase() === normalizedBit)
   );
@@ -141,6 +140,7 @@ export const DigitalCredential = z.object({
   formats: z.array(CredentialFormat).optional(),
   // claims: z.array(Claim), // TODO: [SIW-3978] Should we keep claims?
 });
+export type DigitalCredential = z.infer<typeof DigitalCredential>;
 
 const TaxonomyPurpose = z.object({
   id: z.string(),

--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -27,6 +27,31 @@ const AllowedState = z
   })
   .catchall(z.string());
 
+export type AllowedState = z.infer<typeof AllowedState>;
+
+/**
+ * Given a statusBit (e.g. "0x00", "0x0B") and the allowed_states array
+ * from the catalogue, returns the matching l10n IDs or undefined if not found.
+ * The comparison is case-insensitive to handle uppercase statusBit values
+ * returned by verifyAndParseStatusList against lowercase keys in the catalogue.
+ */
+export const getStatusL10nIds = (
+  statusBit: string,
+  allowedStates: Array<string | AllowedState>
+): { titleL10nId: string; descriptionL10nId: string } | undefined => {
+  const normalizedBit = statusBit.toLowerCase();
+  const match = allowedStates.find(
+    (s): s is AllowedState =>
+      typeof s === "object" &&
+      Object.keys(s).some((k) => k.toLowerCase() === normalizedBit)
+  );
+  if (!match) return undefined;
+  return {
+    titleL10nId: match.title_l10n_id,
+    descriptionL10nId: match.description_l10n_id,
+  };
+};
+
 const CredentialPurpose = z.object({
   id: z.string(),
   description: z.string().optional(),

--- a/src/credentials-catalogue/api/__tests__/getStatusL10nIds.test.ts
+++ b/src/credentials-catalogue/api/__tests__/getStatusL10nIds.test.ts
@@ -1,0 +1,63 @@
+import { getStatusL10nIds } from "../DigitalCredentialsCatalogue";
+
+const validState = {
+  "0x00": "VALID",
+  title_l10n_id: "mDL.VALID.title",
+  description_l10n_id: "mDL.VALID.description",
+};
+
+const invalidState = {
+  "0x01": "INVALID",
+  title_l10n_id: "mDL.INVALID.title",
+  description_l10n_id: "mDL.INVALID.description",
+};
+
+const suspendedState = {
+  "0x02": "SUSPENDED",
+  title_l10n_id: "mDL.SUSPENDED.title",
+  description_l10n_id: "mDL.SUSPENDED.description",
+};
+
+const attrUpdateState = {
+  "0x0b": "ATTRIBUTE_UPDATE",
+  title_l10n_id: "mDL.ATTRIBUTE_UPDATE.title",
+  description_l10n_id: "mDL.ATTRIBUTE_UPDATE.description",
+};
+
+const allowedStates = [validState, invalidState, suspendedState, attrUpdateState];
+
+describe("getStatusL10nIds", () => {
+  it("returns l10n ids for a matching lowercase statusBit", () => {
+    expect(getStatusL10nIds("0x00", allowedStates)).toEqual({
+      titleL10nId: "mDL.VALID.title",
+      descriptionL10nId: "mDL.VALID.description",
+    });
+  });
+
+  it("returns l10n ids for a matching uppercase statusBit (case-insensitive)", () => {
+    expect(getStatusL10nIds("0x0B", allowedStates)).toEqual({
+      titleL10nId: "mDL.ATTRIBUTE_UPDATE.title",
+      descriptionL10nId: "mDL.ATTRIBUTE_UPDATE.description",
+    });
+  });
+
+  it("returns undefined when statusBit is not in the list", () => {
+    expect(getStatusL10nIds("0x03", allowedStates)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty allowedStates array", () => {
+    expect(getStatusL10nIds("0x00", [])).toBeUndefined();
+  });
+
+  it("skips string entries (v1.0.0 format) without crashing", () => {
+    const mixedStates = ["VALID", "INVALID", validState];
+    expect(getStatusL10nIds("0x00", mixedStates)).toEqual({
+      titleL10nId: "mDL.VALID.title",
+      descriptionL10nId: "mDL.VALID.description",
+    });
+  });
+
+  it("returns undefined when allowedStates contains only strings", () => {
+    expect(getStatusL10nIds("0x00", ["VALID", "INVALID"])).toBeUndefined();
+  });
+});

--- a/src/credentials-catalogue/api/__tests__/getStatusL10nIds.test.ts
+++ b/src/credentials-catalogue/api/__tests__/getStatusL10nIds.test.ts
@@ -1,4 +1,14 @@
-import { getStatusL10nIds } from "../DigitalCredentialsCatalogue";
+import {
+  getStatusL10nIds,
+  type DigitalCredential,
+} from "../DigitalCredentialsCatalogue";
+
+const makeCredential = (
+  allowedStates: DigitalCredential["validity_info"]["allowed_states"]
+): DigitalCredential =>
+  ({
+    validity_info: { allowed_states: allowedStates },
+  }) as DigitalCredential;
 
 const validState = {
   "0x00": "VALID",
@@ -24,45 +34,53 @@ const attrUpdateState = {
   description_l10n_id: "mDL.ATTRIBUTE_UPDATE.description",
 };
 
-const allowedStates = [
-  validState,
-  invalidState,
-  suspendedState,
-  attrUpdateState,
-];
-
 describe("getStatusL10nIds", () => {
   it("returns l10n ids for a matching lowercase statusBit", () => {
-    expect(getStatusL10nIds("0x00", allowedStates)).toEqual({
+    const credential = makeCredential([
+      validState,
+      invalidState,
+      suspendedState,
+      attrUpdateState,
+    ]);
+    expect(getStatusL10nIds("0x00", credential)).toEqual({
       titleL10nId: "mDL.VALID.title",
       descriptionL10nId: "mDL.VALID.description",
     });
   });
 
   it("returns l10n ids for a matching uppercase statusBit (case-insensitive)", () => {
-    expect(getStatusL10nIds("0x0B", allowedStates)).toEqual({
+    const credential = makeCredential([
+      validState,
+      invalidState,
+      suspendedState,
+      attrUpdateState,
+    ]);
+    expect(getStatusL10nIds("0x0B", credential)).toEqual({
       titleL10nId: "mDL.ATTRIBUTE_UPDATE.title",
       descriptionL10nId: "mDL.ATTRIBUTE_UPDATE.description",
     });
   });
 
   it("returns undefined when statusBit is not in the list", () => {
-    expect(getStatusL10nIds("0x03", allowedStates)).toBeUndefined();
+    const credential = makeCredential([validState, invalidState]);
+    expect(getStatusL10nIds("0x03", credential)).toBeUndefined();
   });
 
-  it("returns undefined for an empty allowedStates array", () => {
-    expect(getStatusL10nIds("0x00", [])).toBeUndefined();
+  it("returns undefined for an empty allowed_states array", () => {
+    const credential = makeCredential([]);
+    expect(getStatusL10nIds("0x00", credential)).toBeUndefined();
   });
 
   it("skips string entries (v1.0.0 format) without crashing", () => {
-    const mixedStates = ["VALID", "INVALID", validState];
-    expect(getStatusL10nIds("0x00", mixedStates)).toEqual({
+    const credential = makeCredential(["VALID", "INVALID", validState]);
+    expect(getStatusL10nIds("0x00", credential)).toEqual({
       titleL10nId: "mDL.VALID.title",
       descriptionL10nId: "mDL.VALID.description",
     });
   });
 
-  it("returns undefined when allowedStates contains only strings", () => {
-    expect(getStatusL10nIds("0x00", ["VALID", "INVALID"])).toBeUndefined();
+  it("returns undefined when allowed_states contains only strings", () => {
+    const credential = makeCredential(["VALID", "INVALID"]);
+    expect(getStatusL10nIds("0x00", credential)).toBeUndefined();
   });
 });

--- a/src/credentials-catalogue/api/__tests__/getStatusL10nIds.test.ts
+++ b/src/credentials-catalogue/api/__tests__/getStatusL10nIds.test.ts
@@ -24,7 +24,12 @@ const attrUpdateState = {
   description_l10n_id: "mDL.ATTRIBUTE_UPDATE.description",
 };
 
-const allowedStates = [validState, invalidState, suspendedState, attrUpdateState];
+const allowedStates = [
+  validState,
+  invalidState,
+  suspendedState,
+  attrUpdateState,
+];
 
 describe("getStatusL10nIds", () => {
   it("returns l10n ids for a matching lowercase statusBit", () => {

--- a/src/credentials-catalogue/api/index.ts
+++ b/src/credentials-catalogue/api/index.ts
@@ -1,7 +1,7 @@
 import {
   getStatusL10nIds,
-  type AllowedState,
   type CatalogueTranslations,
+  type DigitalCredential,
   type DigitalCredentialsCatalogue,
   type LocalizationInfo,
   type Taxonomy,
@@ -54,8 +54,8 @@ export interface CredentialsCatalogueApi {
 
 export {
   getStatusL10nIds,
-  type AllowedState,
   type CatalogueTranslations,
+  type DigitalCredential,
   type DigitalCredentialsCatalogue,
   type LocalizationInfo,
   type Taxonomy,

--- a/src/credentials-catalogue/api/index.ts
+++ b/src/credentials-catalogue/api/index.ts
@@ -2,7 +2,6 @@ import {
   type CatalogueTranslations,
   type DigitalCredential,
   type DigitalCredentialsCatalogue,
-  type GetStatusL10nIds,
   type LocalizationInfo,
   type Taxonomy,
 } from "./DigitalCredentialsCatalogue";
@@ -59,14 +58,16 @@ export interface CredentialsCatalogueApi {
    *
    * @since 1.0.0
    */
-  getStatusL10nIds: GetStatusL10nIds;
+  getStatusL10nIds(
+    statusBit: string,
+    credentialConfig: DigitalCredential
+  ): { titleL10nId: string; descriptionL10nId: string } | undefined;
 }
 
 export {
   type CatalogueTranslations,
   type DigitalCredential,
   type DigitalCredentialsCatalogue,
-  type GetStatusL10nIds,
   type LocalizationInfo,
   type Taxonomy,
 };

--- a/src/credentials-catalogue/api/index.ts
+++ b/src/credentials-catalogue/api/index.ts
@@ -1,4 +1,6 @@
 import {
+  getStatusL10nIds,
+  type AllowedState,
   type CatalogueTranslations,
   type DigitalCredentialsCatalogue,
   type LocalizationInfo,
@@ -51,6 +53,8 @@ export interface CredentialsCatalogueApi {
 }
 
 export {
+  getStatusL10nIds,
+  type AllowedState,
   type CatalogueTranslations,
   type DigitalCredentialsCatalogue,
   type LocalizationInfo,

--- a/src/credentials-catalogue/api/index.ts
+++ b/src/credentials-catalogue/api/index.ts
@@ -1,8 +1,8 @@
 import {
-  getStatusL10nIds,
   type CatalogueTranslations,
   type DigitalCredential,
   type DigitalCredentialsCatalogue,
+  type GetStatusL10nIds,
   type LocalizationInfo,
   type Taxonomy,
 } from "./DigitalCredentialsCatalogue";
@@ -50,13 +50,23 @@ export interface CredentialsCatalogueApi {
     locales: string[],
     ctx?: FetchContext
   ): Promise<CatalogueTranslations>;
+
+  /**
+   * Given a statusBit (e.g. "0x00", "0x0B") and a DigitalCredential from the
+   * catalogue, returns the matching l10n IDs or undefined if not found.
+   * The comparison is case-insensitive to handle uppercase statusBit values
+   * returned by verifyAndParseStatusList against lowercase keys in the catalogue.
+   *
+   * @since 1.0.0
+   */
+  getStatusL10nIds: GetStatusL10nIds;
 }
 
 export {
-  getStatusL10nIds,
   type CatalogueTranslations,
   type DigitalCredential,
   type DigitalCredentialsCatalogue,
+  type GetStatusL10nIds,
   type LocalizationInfo,
   type Taxonomy,
 };

--- a/src/credentials-catalogue/common/__tests__/get-status-l10n-ids.ts
+++ b/src/credentials-catalogue/common/__tests__/get-status-l10n-ids.ts
@@ -1,10 +1,8 @@
-import {
-  getStatusL10nIds,
-  type DigitalCredential,
-} from "../DigitalCredentialsCatalogue";
+import { getStatusL10nIds } from "../get-status-l10n-ids";
+import type { DigitalCredential } from "../../api/DigitalCredentialsCatalogue";
 
 const makeCredential = (
-  allowedStates: DigitalCredential["validity_info"]["allowed_states"]
+  allowedStates: DigitalCredential["validity_info"]["allowed_states"],
 ): DigitalCredential =>
   ({
     validity_info: { allowed_states: allowedStates },

--- a/src/credentials-catalogue/common/__tests__/get-status-l10n-ids.ts
+++ b/src/credentials-catalogue/common/__tests__/get-status-l10n-ids.ts
@@ -2,7 +2,7 @@ import { getStatusL10nIds } from "../get-status-l10n-ids";
 import type { DigitalCredential } from "../../api/DigitalCredentialsCatalogue";
 
 const makeCredential = (
-  allowedStates: DigitalCredential["validity_info"]["allowed_states"],
+  allowedStates: DigitalCredential["validity_info"]["allowed_states"]
 ): DigitalCredential =>
   ({
     validity_info: { allowed_states: allowedStates },

--- a/src/credentials-catalogue/common/get-status-l10n-ids.ts
+++ b/src/credentials-catalogue/common/get-status-l10n-ids.ts
@@ -1,0 +1,27 @@
+import {
+  AllowedState,
+  type DigitalCredential,
+} from "../api/DigitalCredentialsCatalogue";
+
+/**
+ * Given a statusBit (e.g. "0x00", "0x0B") and a DigitalCredential from the
+ * catalogue, returns the matching l10n IDs or undefined if not found.
+ * The comparison is case-insensitive to handle uppercase statusBit values
+ * returned by verifyAndParseStatusList against lowercase keys in the catalogue.
+ */
+export const getStatusL10nIds = (
+  statusBit: string,
+  credentialConfig: DigitalCredential
+): { titleL10nId: string; descriptionL10nId: string } | undefined => {
+  const normalizedBit = statusBit.toLowerCase();
+  const match = credentialConfig.validity_info.allowed_states.find(
+    (s): s is AllowedState =>
+      typeof s === "object" &&
+      Object.keys(s).some((k) => k.toLowerCase() === normalizedBit)
+  );
+  if (!match) return undefined;
+  return {
+    titleL10nId: match.title_l10n_id,
+    descriptionL10nId: match.description_l10n_id,
+  };
+};

--- a/src/credentials-catalogue/common/get-status-l10n-ids.ts
+++ b/src/credentials-catalogue/common/get-status-l10n-ids.ts
@@ -1,7 +1,5 @@
-import {
-  AllowedState,
-  type DigitalCredential,
-} from "../api/DigitalCredentialsCatalogue";
+import { AllowedState } from "../api/DigitalCredentialsCatalogue";
+import { type CredentialsCatalogueApi } from "../api";
 
 /**
  * Given a statusBit (e.g. "0x00", "0x0B") and a DigitalCredential from the
@@ -9,10 +7,10 @@ import {
  * The comparison is case-insensitive to handle uppercase statusBit values
  * returned by verifyAndParseStatusList against lowercase keys in the catalogue.
  */
-export const getStatusL10nIds = (
-  statusBit: string,
-  credentialConfig: DigitalCredential
-): { titleL10nId: string; descriptionL10nId: string } | undefined => {
+export const getStatusL10nIds: CredentialsCatalogueApi["getStatusL10nIds"] = (
+  statusBit,
+  credentialConfig
+) => {
   const normalizedBit = statusBit.toLowerCase();
   const match = credentialConfig.validity_info.allowed_states.find(
     (s): s is AllowedState =>

--- a/src/credentials-catalogue/v1.0.0/index.ts
+++ b/src/credentials-catalogue/v1.0.0/index.ts
@@ -1,6 +1,8 @@
 import type { CredentialsCatalogueApi } from "../api";
 import { fetchAndParseCatalogue } from "./fetch-and-parse-catalogue";
+import { getStatusL10nIds } from "../common/get-status-l10n-ids";
 
 export const CredentialsCatalogue: CredentialsCatalogueApi = {
   fetchAndParseCatalogue,
+  getStatusL10nIds,
 };

--- a/src/credentials-catalogue/v1.3.3/index.ts
+++ b/src/credentials-catalogue/v1.3.3/index.ts
@@ -1,8 +1,10 @@
 import type { CredentialsCatalogueApi } from "../api";
 import { fetchAndParseCatalogue } from "./fetch-and-parse-catalogue";
 import { fetchTranslations } from "./fetch-translations";
+import { getStatusL10nIds } from "../common/get-status-l10n-ids";
 
 export const CredentialsCatalogue: CredentialsCatalogueApi = {
   fetchAndParseCatalogue,
   fetchTranslations,
+  getStatusL10nIds,
 };


### PR DESCRIPTION
#### List of Changes
  - Added `getStatusL10nIds(statusBit, allowedStates)` utility function to `src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts`
  - Exported the `AllowedState` type (inferred from the Zod schema) from the catalogue API
  - Re-exported both from `src/credentials-catalogue/api/index.ts` to make them accessible via the `CredentialsCatalogue` namespace
  - Added unit tests in `src/credentials-catalogue/api/__tests__/getStatusL10nIds.test.ts`

#### Motivation and Context
  The credential catalogue exposes an `allowed_states` array for each credential type, where each entry carries the localisation keys needed to display a
  human-readable title and description for that state:

  ```json
  {
    "0x00": "VALID",
    "title_l10n_id": "mDL.VALID.title",
    "description_l10n_id": "mDL.VALID.description"
  }
  ```

  At runtime, `verifyAndParseStatusList` returns a `statusBit` (e.g. `"0x00"`, `"0x0B"`) representing the credential's current state read from the status list
  JWT. There was no utility to bridge the two: given a `statusBit`, find the matching `allowed_states` entry and retrieve its l10n keys.

  This function is the missing link that allows consumers to resolve a runtime status bit into localised UI strings, without having to re-implement the lookup
  (including case-insensitive matching) themselves.

  Note: the comparison is case-insensitive because `verifyAndParseStatusList` produces uppercase hex (`"0x0B"`) while catalogue keys use lowercase (`"0x0b"`).

#### How Has This Been Tested?
Unit tests cover the following cases:
  - Match with a lowercase `statusBit` (`"0x00"`) — nominal path
  - Match with an uppercase `statusBit` (`"0x0B"`) — verifies case-insensitive lookup
  - `statusBit` not present in `allowedStates` → returns `undefined`
  - Empty `allowedStates` array → returns `undefined`
  - Mixed array containing plain strings (v1.0.0 catalogue format) alongside `AllowedState` objects → strings are skipped without errors
  - Array containing only plain strings → returns `undefined`

#### Screenshots (if appropriate):
 N/A — no UI changes.

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
