### PR TITLE
chore: make context optional in `completeEaaUserAuthorizationWithQueryMode`

### DIFF
--- a/src/credential/issuance/api/03-complete-user-authorization.ts
+++ b/src/credential/issuance/api/03-complete-user-authorization.ts
@@ -60,7 +60,7 @@ export interface CompleteUserAuthorizationApi {
     issuerConf: IssuerConfig,
     pid: [keyTag: string, credential: string],
     redirectUri: string,
-    context: {
+    context?: {
       appFetch?: GlobalFetch["fetch"];
     }
   ): Promise<AuthorizationResult>;

--- a/src/credential/issuance/v1.3.3/03-complete-user-authorization.ts
+++ b/src/credential/issuance/v1.3.3/03-complete-user-authorization.ts
@@ -161,7 +161,7 @@ export const completeEaaUserAuthorizationWithQueryMode: IssuanceApi["completeEaa
     issuerConfig,
     pid,
     clientRedirectUri,
-    { appFetch = fetch }
+    { appFetch = fetch } = {}
   ) => {
     Logger.log(
       LogLevel.DEBUG,


### PR DESCRIPTION
#### List of Changes

- The `context` argument is now optional for a simpler API