### PR TITLE
fix: [SIW-4412] Get mdoc expiration and issuedAt from validityInfo

### DIFF
--- a/src/credential/issuance/common/06-verify-and-parse-credential.mdoc.ts
+++ b/src/credential/issuance/common/06-verify-and-parse-credential.mdoc.ts
@@ -1,12 +1,10 @@
 import type { CBOR } from "@pagopa/io-react-native-iso18013";
 import type { CryptoContext } from "@pagopa/io-react-native-jwt";
 import type { PublicKey } from "@pagopa/io-react-native-crypto";
-import { extractElementValueAsDate } from "../../../mdoc/converter";
 import {
   getParsedCredentialClaimKey,
   verify as verifyMdoc,
 } from "../../../mdoc";
-import { MDOC_DEFAULT_NAMESPACE } from "../../../mdoc/const";
 import { IoWalletError } from "../../../utils/errors";
 import type { Out } from "../../../utils/misc";
 import { isSameThumbprint } from "../../../utils/jwk";
@@ -209,28 +207,14 @@ export const verifyAndParseCredentialMDoc: IssuanceApi["verifyAndParseCredential
       ignoreMissingAttributes
     );
 
-    const expirationDate = extractElementValueAsDate(
-      parsedCredential?.[
-        getParsedCredentialClaimKey(MDOC_DEFAULT_NAMESPACE, "expiry_date")
-      ]?.value as string
-    );
-    if (!expirationDate) {
-      throw new IoWalletError(`expirationDate must be present!!`);
-    }
-    expirationDate.setDate(expirationDate.getDate() + 1);
-
-    const maybeIssuedAt = extractElementValueAsDate(
-      parsedCredential?.[
-        getParsedCredentialClaimKey(MDOC_DEFAULT_NAMESPACE, "issue_date")
-      ]?.value as string
-    );
-    maybeIssuedAt?.setDate(maybeIssuedAt.getDate() + 1);
+    const { signed, validUntil } =
+      decoded.issuerSigned.issuerAuth.payload.validityInfo;
 
     return {
       parsedCredential,
       credential,
       credentialConfigurationId,
-      expiration: expirationDate,
-      issuedAt: maybeIssuedAt ?? undefined,
+      expiration: validUntil,
+      issuedAt: signed,
     };
   };

--- a/src/credential/issuance/v1.3.3/03-complete-user-authorization.ts
+++ b/src/credential/issuance/v1.3.3/03-complete-user-authorization.ts
@@ -174,7 +174,10 @@ export const completeEaaUserAuthorizationWithQueryMode: IssuanceApi["completeEaa
       pid,
     });
 
-    Logger.log(LogLevel.DEBUG, `Authz response: ${authzResponse}`);
+    Logger.log(
+      LogLevel.DEBUG,
+      `Authz response: ${JSON.stringify(authzResponse)}`
+    );
 
     const { redirect_uri } = await fetchAuthorizationResponse({
       authorizationResponseJarm: authzResponse.jarm.responseJwe,


### PR DESCRIPTION
#### Motivation and Context

This PR fixes an inconsistency between SD-JWT and mdoc credentials that affects the `expiration` and `issuedAt` properties returned by `verifyAndParseCredential`.

Currently, SD-JWT uses the `exp` and `iat` claim of the JWT, matching the digital document, while mdoc uses the expiration and issue date of the physical document from the namespaces.

With this PR the information is taken from the Mobile Security Object's `validityInfo` to match the digital document.