### PR TITLE
feat: [WLS-132] Update SDK and align Credential Offer API

### DIFF
--- a/example/src/store/reducers/offer.ts
+++ b/example/src/store/reducers/offer.ts
@@ -7,7 +7,7 @@ import { asyncStatusInitial } from "../utils";
 import type { CredentialOffer } from "@pagopa/io-react-native-wallet";
 
 type CredentialOfferState = {
-  offer?: CredentialOffer.ExtractGrantDetailsResult;
+  offer?: CredentialOffer.CredentialOffer;
   asyncStatus: AsyncStatus;
 };
 

--- a/example/src/thunks/credential.ts
+++ b/example/src/thunks/credential.ts
@@ -1,6 +1,7 @@
 import {
   createCryptoContextFor,
   CredentialIssuance,
+  CredentialOffer,
   CredentialStatus,
   IoWallet,
 } from "@pagopa/io-react-native-wallet";
@@ -21,6 +22,7 @@ import {
   getCredentialStatusFromStatusList,
 } from "../utils/credential";
 import { WIA_KEYTAG } from "../utils/crypto";
+import appFetch from "../utils/fetch";
 import { getEnv } from "../utils/environment";
 import { selectPid } from "../store/reducers/pid";
 import { createAppAsyncThunk } from "./utils";
@@ -56,6 +58,7 @@ export type CredentialStatusResult =
 type GetCredentialThunkInput = {
   credentialType: SupportedCredentialsWithoutPid;
   batchSize?: number;
+  credentialOffer?: CredentialOffer.CredentialOffer;
 };
 
 /**
@@ -81,6 +84,9 @@ type GetCredentialStatusListThunkInput = {
  * Thunk to obtain a new credential.
  * @param args.idPhint- The idPhint for the Identity Provider to use if the requested credential is a `PersonIdentificationData`
  * @param args.credentialType - The type of the requested credential to obtain
+ * @param args.credentialOffer - (optional) A resolved credential offer. When provided, the issuer URL
+ *   and the authorization parameters (authorization server, scope, issuer state) are taken from it, and
+ *   the offer is validated against the resolved Issuer metadata before starting the issuance.
  * @returns The obtained credential result
  */
 export const getCredentialThunk = createAppAsyncThunk<
@@ -109,7 +115,7 @@ export const getCredentialThunk = createAppAsyncThunk<
   const { WALLET_EAA_PROVIDER_BASE_URL, REDIRECT_URI, WALLET_TA_BASE_URL } =
     getEnv(env);
 
-  const { credentialType, batchSize } = args;
+  const { credentialType, batchSize, credentialOffer } = args;
 
   // Get the PID from the store
   const pid = selectPid(getState());
@@ -130,9 +136,44 @@ export const getCredentialThunk = createAppAsyncThunk<
     return undefined;
   };
 
+  // When the issuance originates from a credential offer, the issuer URL comes
+  // from the offer and overrides the default EAA provider. The authorization_code
+  // grant may also carry a specific authorization server (required when the Issuer
+  // relies on more than one), as well as the `scope` and `issuer_state` to be
+  // forwarded to the PAR.
+  const issuerUrl = credentialOffer
+    ? credentialOffer.credential_issuer
+    : WALLET_EAA_PROVIDER_BASE_URL.value(itwVersion);
+
+  const authorizationCodeGrant = credentialOffer
+    ? wallet.CredentialsOffer.extractGrantDetails(credentialOffer)
+        .authorizationCodeGrant
+    : undefined;
+
+  // Evaluate issuer trust, selecting the authorization server from the offer
+  // when present.
+  const { issuerConf } = await wallet.CredentialIssuance.evaluateIssuerTrust(
+    issuerUrl,
+    {
+      appFetch,
+      authorizationServer: authorizationCodeGrant?.authorizationServer,
+    }
+  );
+
+  // Validate the credential offer against the resolved Issuer metadata. Only
+  // performed when the issuance was started from a credential offer.
+  if (credentialOffer) {
+    await wallet.CredentialsOffer.validateCredentialOffer({
+      offer: credentialOffer,
+      credentialIssuerMetadata: issuerConf.authorization_servers
+        ? { authorization_servers: issuerConf.authorization_servers }
+        : {},
+    });
+  }
+
   return await getCredential({
     itwVersion,
-    credentialIssuerUrl: WALLET_EAA_PROVIDER_BASE_URL.value(itwVersion),
+    issuerConf,
     trustAnchorUrl: WALLET_TA_BASE_URL,
     redirectUri: REDIRECT_URI,
     // For simplicity, in the sample app, we assume that the `credentialType` corresponds to the `credentialId`,
@@ -143,6 +184,8 @@ export const getCredentialThunk = createAppAsyncThunk<
     generateKeysWithAttestation,
     wiaCryptoContext,
     batchSize,
+    scope: authorizationCodeGrant?.scope,
+    issuerState: authorizationCodeGrant?.issuerState,
   });
 });
 

--- a/example/src/thunks/offer.ts
+++ b/example/src/thunks/offer.ts
@@ -24,5 +24,25 @@ export const getCredentialOfferThunk = createAppAsyncThunk<
   );
 
   // 2) Extract grant details
-  return wallet.CredentialsOffer.extractGrantDetails(credentialOffer);
+  const grantDetails =
+    wallet.CredentialsOffer.extractGrantDetails(credentialOffer);
+
+  // 3) Evaluate issuer trust
+  const { issuerConf } = await wallet.CredentialIssuance.evaluateIssuerTrust(
+    credentialOffer.credential_issuer,
+    {
+      authorizationServer:
+        grantDetails.authorizationCodeGrant.authorizationServer,
+    }
+  );
+
+  // 4) Validate credential offer
+  await wallet.CredentialsOffer.validateCredentialOffer({
+    offer: credentialOffer,
+    credentialIssuerMetadata: {
+      authorization_servers: issuerConf.authorization_servers,
+    },
+  });
+
+  return grantDetails;
 });

--- a/example/src/thunks/offer.ts
+++ b/example/src/thunks/offer.ts
@@ -33,6 +33,7 @@ export const getCredentialOfferThunk = createAppAsyncThunk<
     {
       authorizationServer:
         grantDetails.authorizationCodeGrant.authorizationServer,
+      appFetch,
     }
   );
 

--- a/example/src/thunks/offer.ts
+++ b/example/src/thunks/offer.ts
@@ -2,48 +2,47 @@ import { CredentialOffer, IoWallet } from "@pagopa/io-react-native-wallet";
 import appFetch from "../utils/fetch";
 import { createAppAsyncThunk } from "./utils";
 import { selectItwVersion } from "../store/reducers/environment";
+import { getCredentialThunk } from "./credential";
+import type { SupportedCredentialsWithoutPid } from "../store/types";
 
 export type GetCredentialOfferThunkInput = {
   qrcode: string;
 };
 
-export type GetCredentialOfferThunkOutput =
-  CredentialOffer.ExtractGrantDetailsResult;
+export type GetCredentialOfferThunkOutput = CredentialOffer.CredentialOffer;
 
 export const getCredentialOfferThunk = createAppAsyncThunk<
   GetCredentialOfferThunkOutput,
   GetCredentialOfferThunkInput
->("credential/offerGet", async (args, { getState }) => {
+>("credential/offerGet", async (args, { getState, dispatch }) => {
   const itwVersion = selectItwVersion(getState());
   const wallet = new IoWallet({ version: itwVersion });
 
-  // 1) Resolve and validate the credential offer
+  // Resolve the credential offer (by value or by reference)
   const credentialOffer = await wallet.CredentialsOffer.resolveCredentialOffer(
     args.qrcode,
     { fetch: appFetch }
   );
 
-  // 2) Extract grant details
-  const grantDetails =
-    wallet.CredentialsOffer.extractGrantDetails(credentialOffer);
+  // For simplicity, the sample app drives the issuance with the first offered
+  // credential configuration id, assuming it maps to a supported credential type.
+  const [credentialConfigurationId] =
+    credentialOffer.credential_configuration_ids;
+  if (!credentialConfigurationId) {
+    throw new Error(
+      "The credential offer does not contain any credential configuration id"
+    );
+  }
 
-  // 3) Evaluate issuer trust
-  const { issuerConf } = await wallet.CredentialIssuance.evaluateIssuerTrust(
-    credentialOffer.credential_issuer,
-    {
-      authorizationServer:
-        grantDetails.authorizationCodeGrant.authorizationServer,
-      appFetch,
-    }
-  );
+  // Hand over to the credential issuance flow, which evaluates the issuer trust
+  // and validates the credential offer before obtaining the credential.
+  await dispatch(
+    getCredentialThunk({
+      credentialType:
+        credentialConfigurationId as SupportedCredentialsWithoutPid,
+      credentialOffer,
+    })
+  ).unwrap();
 
-  // 4) Validate credential offer
-  await wallet.CredentialsOffer.validateCredentialOffer({
-    offer: credentialOffer,
-    credentialIssuerMetadata: {
-      authorization_servers: issuerConf.authorization_servers,
-    },
-  });
-
-  return grantDetails;
+  return credentialOffer;
 });

--- a/example/src/utils/credential.ts
+++ b/example/src/utils/credential.ts
@@ -23,18 +23,20 @@ import type { Env } from "./environment";
 /**
  * Implements a flow to obtain a generic credential.
  * @param itwVersion IT-Wallet specifications version
- * @param credentialIssuerUrl - The credential issuer URL
+ * @param issuerConf - The resolved Issuer configuration (issuer trust already evaluated)
  * @param redirectUri - The redirect URI for the authorization flow
  * @param credentialId - The id of the credential to obtain
  * @param credentialKeyTag - The key tag of the crypto key to bind to the credential
  * @param pid - The PID credential
  * @param walletInstanceAttestation - The Wallet Instance Attestation
  * @param wiaCryptoContext - The Wallet Instance Attestation crypto context
+ * @param scope - (optional) OAuth 2.0 scope forwarded to the PAR, from a credential offer
+ * @param issuerState - (optional) issuer state forwarded to the PAR, from a credential offer
  * @returns The obtained credential result
  */
 export const getCredential = async ({
   itwVersion,
-  credentialIssuerUrl,
+  issuerConf,
   trustAnchorUrl,
   redirectUri,
   credentialId,
@@ -43,9 +45,11 @@ export const getCredential = async ({
   generateKeysWithAttestation,
   wiaCryptoContext,
   batchSize = 1,
+  scope,
+  issuerState,
 }: {
   itwVersion: ItwVersion;
-  credentialIssuerUrl: string;
+  issuerConf: CredentialIssuance.IssuerConfig;
   trustAnchorUrl: string;
   redirectUri: string;
   credentialId: SupportedCredentialsWithoutPid;
@@ -56,12 +60,10 @@ export const getCredential = async ({
   ) => Promise<string | undefined>;
   wiaCryptoContext: CryptoContext;
   batchSize?: number;
+  scope?: string;
+  issuerState?: string;
 }): Promise<CredentialResult> => {
   const wallet = new IoWallet({ version: itwVersion });
-
-  // Evaluate issuer trust
-  const { issuerConf } =
-    await wallet.CredentialIssuance.evaluateIssuerTrust(credentialIssuerUrl);
 
   // Start user authorization
   const { issuerRequestUri, clientId, codeVerifier, responseMode } =
@@ -74,6 +76,8 @@ export const getCredential = async ({
         redirectUri,
         wiaCryptoContext,
         appFetch,
+        scope,
+        issuerState,
       }
     );
 

--- a/package.json
+++ b/package.json
@@ -140,11 +140,11 @@
     ]
   },
   "dependencies": {
-    "@pagopa/io-wallet-oauth2": "1.4.2",
-    "@pagopa/io-wallet-oid-federation": "1.4.2",
-    "@pagopa/io-wallet-oid4vci": "1.4.2",
-    "@pagopa/io-wallet-oid4vp": "1.4.2",
-    "@pagopa/io-wallet-utils": "1.4.2",
+    "@pagopa/io-wallet-oauth2": "1.5.2",
+    "@pagopa/io-wallet-oid-federation": "1.5.2",
+    "@pagopa/io-wallet-oid4vci": "1.5.2",
+    "@pagopa/io-wallet-oid4vp": "1.5.2",
+    "@pagopa/io-wallet-utils": "1.5.2",
     "@sd-jwt/core": "^0.19.0",
     "@sd-jwt/crypto-nodejs": "^0.19.0",
     "@sd-jwt/jwt-status-list": "^0.19.0",

--- a/src/credential/issuance/api/01-evaluate-issuer-trust.ts
+++ b/src/credential/issuance/api/01-evaluate-issuer-trust.ts
@@ -8,10 +8,13 @@ export interface EvaluateIssuerTrustApi {
    *
    * @param issuerUrl The base url of the Issuer
    * @param context.appFetch (optional) fetch api implementation. Default: built-in fetch
+   * @param context.authorizationServer (optional) Authorization Server URL selected
+   *   from a credential offer. When provided it must match one of the Credential
+   *   Issuer metadata `authorization_servers`. Only honored from v1.3.3 onwards.
    * @returns The Issuer's configuration
    */
   evaluateIssuerTrust(
     issuerUrl: string,
-    ctx?: { appFetch?: GlobalFetch["fetch"] }
+    ctx?: { appFetch?: GlobalFetch["fetch"]; authorizationServer?: string }
   ): Promise<{ issuerConf: IssuerConfig }>;
 }

--- a/src/credential/issuance/api/02-start-user-authorization.ts
+++ b/src/credential/issuance/api/02-start-user-authorization.ts
@@ -27,6 +27,8 @@ export interface StartUserAuthorizationApi {
    * @param context.walletInstanceAttestation: the Wallet Instance's attestation
    * @param context.redirectUri: the redirect URI
    * @param context.appFetch: (optional) the fetch implementation
+   * @param context.scope: (optional) the OAuth 2.0 scope, forwarded to the PAR. When the issuance is started from a Credential Offer, it comes from the `authorization_code` grant.
+   * @param context.issuerState: (optional) the issuer state, forwarded to the PAR to correlate the authorization request with the Credential Offer.
    * @returns The URI to which the end user should be redirected to start the authentication flow, along with additional authentication parameters
    */
   startUserAuthorization(
@@ -40,6 +42,8 @@ export interface StartUserAuthorizationApi {
       walletInstanceAttestation: string;
       redirectUri: string;
       appFetch?: GlobalFetch["fetch"];
+      scope?: string;
+      issuerState?: string;
     }
   ): Promise<{
     issuerRequestUri: string;

--- a/src/credential/issuance/api/IssuerConfig.ts
+++ b/src/credential/issuance/api/IssuerConfig.ts
@@ -50,6 +50,12 @@ const CredentialConfig = z.intersection(
 export type IssuerConfig = z.infer<typeof IssuerConfig>;
 export const IssuerConfig = z.object({
   credential_issuer: z.string(),
+  /**
+   * Authorization Servers advertised by the Credential Issuer. Present when the
+   * Issuer relies on one or more external Authorization Servers; used to validate
+   * the `authorization_server` selected by a credential offer.
+   */
+  authorization_servers: z.tuple([z.string()], z.string()).optional(),
   pushed_authorization_request_endpoint: z.string(),
   authorization_endpoint: z.string(),
   token_endpoint: z.string(),

--- a/src/credential/issuance/v1.3.3/01-evaluate-issuer-trust.ts
+++ b/src/credential/issuance/v1.3.3/01-evaluate-issuer-trust.ts
@@ -13,6 +13,7 @@ export const evaluateIssuerTrust: IssuanceApi["evaluateIssuerTrust"] = async (
   const issuerMetadata = (await fetchMetadata({
     config: sdkConfigV1_3,
     credentialIssuerUrl: issuerUrl,
+    authorizationServer: context.authorizationServer,
     callbacks: {
       fetch: context.appFetch,
     },

--- a/src/credential/issuance/v1.3.3/02-start-user-authorization.ts
+++ b/src/credential/issuance/v1.3.3/02-start-user-authorization.ts
@@ -22,6 +22,8 @@ export const startUserAuthorization: IssuanceApi["startUserAuthorization"] =
       walletInstanceAttestation,
       redirectUri,
       appFetch = fetch,
+      scope,
+      issuerState,
     } = ctx;
 
     const clientId = await wiaCryptoContext.getPublicKey().then((_) => _.kid);
@@ -76,6 +78,11 @@ export const startUserAuthorization: IssuanceApi["startUserAuthorization"] =
       authorization_details: credentialDefinition,
       codeChallengeMethodsSupported: ["S256"],
       redirectUri,
+      // When the issuance is started from a Credential Offer, the `scope` and
+      // `issuer_state` carried by the authorization_code grant are forwarded to
+      // the PAR. They are `undefined` (and thus omitted) for the regular flow.
+      scope,
+      issuerState,
       dpop: {
         signer: wiaSigner,
       },

--- a/src/credential/issuance/v1.3.3/mappers.ts
+++ b/src/credential/issuance/v1.3.3/mappers.ts
@@ -45,8 +45,17 @@ export const mapToIssuerConfig = createMapper<
       federation_entity,
     } = x.metadata;
 
+    // The Issuer's own `oauth_authorization_server` always describes the Issuer
+    // itself. When a credential offer selected a *different* Authorization
+    // Server, its metadata is surfaced separately through that server's
+    // federation claims, and the Authorization Server endpoints must be taken
+    // from there. Fall back to the Issuer's own server otherwise.
+    const oauthAuthorizationServer =
+      x.authorization_server_federation_claims?.metadata
+        ?.oauth_authorization_server ?? oauth_authorization_server;
+
     assert(
-      oauth_authorization_server,
+      oauthAuthorizationServer,
       "oauth_authorization_server is required in Issuer metadata"
     );
     assert(
@@ -55,19 +64,20 @@ export const mapToIssuerConfig = createMapper<
     );
 
     return {
-      authorization_endpoint: oauth_authorization_server.authorization_endpoint,
+      authorization_endpoint: oauthAuthorizationServer.authorization_endpoint,
       credential_endpoint: openid_credential_issuer.credential_endpoint,
       credential_issuer: openid_credential_issuer.credential_issuer,
+      authorization_servers: openid_credential_issuer.authorization_servers,
       credential_configurations_supported: mapCredentialConfigurationsSupported(
         openid_credential_issuer
       ),
       keys: [
         ...openid_credential_issuer.jwks.keys,
-        ...oauth_authorization_server.jwks.keys,
+        ...oauthAuthorizationServer.jwks.keys,
       ] as JWK[],
       pushed_authorization_request_endpoint:
-        oauth_authorization_server.pushed_authorization_request_endpoint,
-      token_endpoint: oauth_authorization_server.token_endpoint,
+        oauthAuthorizationServer.pushed_authorization_request_endpoint,
+      token_endpoint: oauthAuthorizationServer.token_endpoint,
       nonce_endpoint: openid_credential_issuer.nonce_endpoint ?? "",
       federation_entity: federation_entity ?? {},
       credential_issuance_batch_size:

--- a/src/credential/offer/api/02-extract-grant-details.ts
+++ b/src/credential/offer/api/02-extract-grant-details.ts
@@ -4,7 +4,7 @@ export interface ExtractGrantDetailsApi {
   /**
    * Extract grant details from a resolved Credential Offer.
    *
-   * @param offer - A previously resolved {@link CredentialOffer}.
+   * @param offer - A previously resolved Credential Offer.
    * @returns The extracted {@link ExtractGrantDetailsResult} containing
    *   the grant type and its parameters.
    * @throws {InvalidCredentialOfferError} If no supported grant type is found.

--- a/src/credential/offer/api/03-validate-credential-offer.ts
+++ b/src/credential/offer/api/03-validate-credential-offer.ts
@@ -1,0 +1,19 @@
+import type { ValidateCredentialOfferOptions } from "@pagopa/io-wallet-oid4vci";
+import type { CredentialOffer } from "./types";
+
+export interface ValidateCredentialOfferApi {
+  /**
+   * Validate a resolved Credential Offer against the Credential Issuer metadata.
+   *
+   * @param options.offer - A previously resolved Credential Offer.
+   * @param options.credentialIssuerMetadata - The Credential Issuer metadata used
+   *   to cross-check the offer (e.g. the `authorization_server` selected by the
+   *   offer against the advertised `authorization_servers`).
+   * @returns A promise that resolves when the Credential Offer is valid.
+   * @throws {InvalidCredentialOfferError} If the Credential Offer fails validation.
+   */
+  validateCredentialOffer(options: {
+    offer: CredentialOffer;
+    credentialIssuerMetadata: ValidateCredentialOfferOptions["credentialIssuerMetadata"];
+  }): Promise<void>;
+}

--- a/src/credential/offer/api/index.ts
+++ b/src/credential/offer/api/index.ts
@@ -1,8 +1,10 @@
 import type { ResolveCredentialOfferApi } from "./01-resolve-credential-offer";
 import type { ExtractGrantDetailsApi } from "./02-extract-grant-details";
+import type { ValidateCredentialOfferApi } from "./03-validate-credential-offer";
 
 export interface OfferApi
   extends ResolveCredentialOfferApi,
-    ExtractGrantDetailsApi {}
+    ExtractGrantDetailsApi,
+    ValidateCredentialOfferApi {}
 
 export * from "./types";

--- a/src/credential/offer/v1.0.0/index.ts
+++ b/src/credential/offer/v1.0.0/index.ts
@@ -8,4 +8,7 @@ export const Offer: OfferApi = {
   extractGrantDetails() {
     throw new UnimplementedFeatureError("extractGrantDetails", "1.0.0");
   },
+  validateCredentialOffer() {
+    throw new UnimplementedFeatureError("validateCredentialOffer", "1.0.0");
+  },
 };

--- a/src/credential/offer/v1.3.3/01-resolve-credential-offer.ts
+++ b/src/credential/offer/v1.3.3/01-resolve-credential-offer.ts
@@ -1,35 +1,26 @@
 import {
   resolveCredentialOffer as sdkResolveCredentialOffer,
-  validateCredentialOffer,
   CredentialOfferError,
 } from "@pagopa/io-wallet-oid4vci";
-import {
-  InvalidQRCodeError,
-  InvalidCredentialOfferError,
-} from "../common/errors";
+import { InvalidQRCodeError } from "../common/errors";
 import type { OfferApi } from "../api";
+import { sdkConfigV1_3 } from "../../../utils/config";
 
 /**
  * v1.3.3 implementation — first step of the User Request Flow
  * (IT-Wallet spec, Section 12.1.2).
  *
  * Delegates to the SDK's {@link sdkResolveCredentialOffer} for URI parsing
- * and by-reference fetching, then to {@link validateCredentialOffer} for
- * IT-Wallet v1.3 structural checks:
- * - `credential_issuer` must be an HTTPS URL
- * - `grants` object is required
- * - `authorization_code` grant is required
- * - `scope` is required within `authorization_code`
+ * and by-reference fetching of the Credential Offer.
  *
  * Supported URI schemes: `openid-credential-offer://`, `haip-vci://`, `https://`.
  *
- * Cross-validation against Credential Issuer metadata (e.g. matching
- * `credential_configuration_ids` or `authorization_server`) is **not** performed
- * here; per the spec it belongs to the Issuance Flow.
+ * Structural validation and cross-validation against the Credential Issuer
+ * metadata are **not** performed here; they belong to the dedicated
+ * validate-credential-offer step of the flow.
  *
  * Resolution errors (bad scheme, missing params, network failure) are mapped
- * to {@link InvalidQRCodeError}; validation errors are mapped to
- * {@link InvalidCredentialOfferError}.
+ * to {@link InvalidQRCodeError}.
  */
 export const resolveCredentialOffer: OfferApi["resolveCredentialOffer"] =
   async (credentialOffer, callbacks = {}) => {
@@ -37,21 +28,12 @@ export const resolveCredentialOffer: OfferApi["resolveCredentialOffer"] =
 
     // Parse the URI and fetch the offer when transmitted by reference
     const resolved = await sdkResolveCredentialOffer({
+      config: sdkConfigV1_3,
       credentialOffer,
       callbacks: { fetch: fetchFn },
     }).catch((e: unknown) => {
       if (e instanceof CredentialOfferError) {
         throw new InvalidQRCodeError(e.message);
-      }
-      throw e;
-    });
-
-    // Structural validation (no metadata cross-checks at this stage)
-    await validateCredentialOffer({
-      credentialOffer: resolved,
-    }).catch((e: unknown) => {
-      if (e instanceof CredentialOfferError) {
-        throw new InvalidCredentialOfferError(e.message);
       }
       throw e;
     });

--- a/src/credential/offer/v1.3.3/02-extract-grant-details.ts
+++ b/src/credential/offer/v1.3.3/02-extract-grant-details.ts
@@ -5,6 +5,7 @@ import {
 import { InvalidCredentialOfferError } from "../common/errors";
 import { withMappedErrors } from "../../../utils/errors";
 import type { OfferApi } from "../api";
+import { sdkConfigV1_3 } from "../../../utils/config";
 
 /**
  * v1.3.3 implementation — second and final step of the User Request Flow
@@ -21,7 +22,11 @@ import type { OfferApi } from "../api";
  */
 export const extractGrantDetails: OfferApi["extractGrantDetails"] = (offer) =>
   withMappedErrors(
-    () => sdkExtractGrantDetails(offer),
+    () =>
+      sdkExtractGrantDetails({
+        config: sdkConfigV1_3,
+        credentialOffer: offer,
+      }),
     CredentialOfferError,
     (e) => new InvalidCredentialOfferError(e.message)
   );

--- a/src/credential/offer/v1.3.3/03-validate-credential-offer.ts
+++ b/src/credential/offer/v1.3.3/03-validate-credential-offer.ts
@@ -1,0 +1,33 @@
+import {
+  validateCredentialOffer as sdkValidateCredentialOffer,
+  CredentialOfferError,
+} from "@pagopa/io-wallet-oid4vci";
+import { InvalidCredentialOfferError } from "../common/errors";
+import type { OfferApi } from "../api";
+import { sdkConfigV1_3 } from "../../../utils/config";
+
+/**
+ * v1.3.3 implementation — validates a resolved Credential Offer against the
+ * Credential Issuer metadata (IT-Wallet spec, Section 12.1.2).
+ *
+ * Performs the IT-Wallet v1.3 structural checks on the offer and, when the
+ * Credential Issuer relies on multiple Authorization Servers, ensures the
+ * `authorization_server` selected by the offer matches one of the advertised
+ * `authorization_servers`.
+ *
+ * Delegates to the SDK's {@link sdkValidateCredentialOffer}; validation errors
+ * are mapped to {@link InvalidCredentialOfferError}.
+ */
+export const validateCredentialOffer: OfferApi["validateCredentialOffer"] =
+  async ({ offer, credentialIssuerMetadata }) => {
+    await sdkValidateCredentialOffer({
+      config: sdkConfigV1_3,
+      credentialOffer: offer,
+      credentialIssuerMetadata,
+    }).catch((e: unknown) => {
+      if (e instanceof CredentialOfferError) {
+        throw new InvalidCredentialOfferError(e.message);
+      }
+      throw e;
+    });
+  };

--- a/src/credential/offer/v1.3.3/__tests__/01-resolve-credential-offer.test.ts
+++ b/src/credential/offer/v1.3.3/__tests__/01-resolve-credential-offer.test.ts
@@ -1,17 +1,12 @@
-import {
-  InvalidQRCodeError,
-  InvalidCredentialOfferError,
-} from "../../common/errors";
+import { InvalidQRCodeError } from "../../common/errors";
 import { resolveCredentialOffer } from "../01-resolve-credential-offer";
+import { sdkConfigV1_3 } from "../../../../utils/config";
 
 const mockResolveCredentialOffer = jest.fn();
-const mockValidateCredentialOffer = jest.fn();
 
 jest.mock("@pagopa/io-wallet-oid4vci", () => ({
   resolveCredentialOffer: (...args: unknown[]) =>
     mockResolveCredentialOffer(...args),
-  validateCredentialOffer: (...args: unknown[]) =>
-    mockValidateCredentialOffer(...args),
   CredentialOfferError: jest.requireActual("@pagopa/io-wallet-oid4vci")
     .CredentialOfferError,
 }));
@@ -31,11 +26,9 @@ const validCredentialOffer = {
 describe("resolveCredentialOffer", () => {
   beforeEach(() => {
     mockResolveCredentialOffer.mockReset();
-    mockValidateCredentialOffer.mockReset();
-    mockValidateCredentialOffer.mockResolvedValue(undefined);
   });
 
-  it("should resolve and validate a credential offer by value", async () => {
+  it("should resolve a credential offer by value", async () => {
     const uri =
       "openid-credential-offer://?credential_offer=" +
       encodeURIComponent(JSON.stringify(validCredentialOffer));
@@ -45,16 +38,14 @@ describe("resolveCredentialOffer", () => {
     const result = await resolveCredentialOffer(uri);
 
     expect(mockResolveCredentialOffer).toHaveBeenCalledWith({
+      config: sdkConfigV1_3,
       credentialOffer: uri,
       callbacks: { fetch: expect.any(Function) },
-    });
-    expect(mockValidateCredentialOffer).toHaveBeenCalledWith({
-      credentialOffer: validCredentialOffer,
     });
     expect(result).toEqual(validCredentialOffer);
   });
 
-  it("should resolve and validate a credential offer by reference", async () => {
+  it("should resolve a credential offer by reference", async () => {
     const uri =
       "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fissuer.example.com%2Foffer";
 
@@ -63,6 +54,7 @@ describe("resolveCredentialOffer", () => {
     const result = await resolveCredentialOffer(uri);
 
     expect(mockResolveCredentialOffer).toHaveBeenCalledWith({
+      config: sdkConfigV1_3,
       credentialOffer: uri,
       callbacks: { fetch: expect.any(Function) },
     });
@@ -76,6 +68,7 @@ describe("resolveCredentialOffer", () => {
     await resolveCredentialOffer("some-uri", { fetch: customFetch });
 
     expect(mockResolveCredentialOffer).toHaveBeenCalledWith({
+      config: sdkConfigV1_3,
       credentialOffer: "some-uri",
       callbacks: { fetch: customFetch },
     });
@@ -94,33 +87,9 @@ describe("resolveCredentialOffer", () => {
     );
   });
 
-  it("should throw InvalidCredentialOfferError when validation fails with CredentialOfferError", async () => {
-    const { CredentialOfferError } = jest.requireActual(
-      "@pagopa/io-wallet-oid4vci"
-    );
-    mockResolveCredentialOffer.mockResolvedValue(validCredentialOffer);
-    mockValidateCredentialOffer.mockRejectedValue(
-      new CredentialOfferError("credential_issuer must be an HTTPS URL")
-    );
-
-    await expect(
-      resolveCredentialOffer("openid-credential-offer://?credential_offer=foo")
-    ).rejects.toThrow(InvalidCredentialOfferError);
-  });
-
   it("should rethrow non-CredentialOfferError from resolve", async () => {
     const unexpectedError = new Error("network failure");
     mockResolveCredentialOffer.mockRejectedValue(unexpectedError);
-
-    await expect(resolveCredentialOffer("some-uri")).rejects.toThrow(
-      unexpectedError
-    );
-  });
-
-  it("should rethrow non-CredentialOfferError from validation", async () => {
-    const unexpectedError = new Error("unexpected");
-    mockResolveCredentialOffer.mockResolvedValue(validCredentialOffer);
-    mockValidateCredentialOffer.mockRejectedValue(unexpectedError);
 
     await expect(resolveCredentialOffer("some-uri")).rejects.toThrow(
       unexpectedError

--- a/src/credential/offer/v1.3.3/__tests__/02-extract-grant-details.test.ts
+++ b/src/credential/offer/v1.3.3/__tests__/02-extract-grant-details.test.ts
@@ -1,6 +1,7 @@
 import type { CredentialOffer } from "@pagopa/io-wallet-oid4vci";
 import { extractGrantDetails } from "../02-extract-grant-details";
 import { InvalidCredentialOfferError } from "../../common/errors";
+import { sdkConfigV1_3 } from "../../../../utils/config";
 
 const mockExtractGrantDetails = jest.fn();
 
@@ -41,7 +42,10 @@ describe("extractGrantDetails", () => {
     const result = extractGrantDetails(validOffer);
 
     expect(result).toEqual(sdkResult);
-    expect(mockExtractGrantDetails).toHaveBeenCalledWith(validOffer);
+    expect(mockExtractGrantDetails).toHaveBeenCalledWith({
+      config: sdkConfigV1_3,
+      credentialOffer: validOffer,
+    });
   });
 
   it("should throw InvalidCredentialOfferError when SDK throws CredentialOfferError", () => {

--- a/src/credential/offer/v1.3.3/__tests__/03-validate-credential-offer.test.ts
+++ b/src/credential/offer/v1.3.3/__tests__/03-validate-credential-offer.test.ts
@@ -1,0 +1,72 @@
+import type { CredentialOffer } from "@pagopa/io-wallet-oid4vci";
+import { validateCredentialOffer } from "../03-validate-credential-offer";
+import { InvalidCredentialOfferError } from "../../common/errors";
+import { sdkConfigV1_3 } from "../../../../utils/config";
+
+const mockValidateCredentialOffer = jest.fn();
+
+jest.mock("@pagopa/io-wallet-oid4vci", () => ({
+  validateCredentialOffer: (...args: unknown[]) =>
+    mockValidateCredentialOffer(...args),
+  CredentialOfferError: jest.requireActual("@pagopa/io-wallet-oid4vci")
+    .CredentialOfferError,
+}));
+
+const validOffer: CredentialOffer = {
+  credential_issuer: "https://issuer.example.com",
+  credential_configuration_ids: ["org.iso.18013.5.1.mDL"],
+  grants: {
+    authorization_code: {
+      scope: "test-scope",
+      issuer_state: "some-issuer-state",
+      authorization_server: "https://auth.example.com",
+    },
+  },
+};
+
+const credentialIssuerMetadata = {
+  authorization_servers: ["https://auth.example.com"] as [string, ...string[]],
+};
+
+describe("validateCredentialOffer", () => {
+  beforeEach(() => {
+    mockValidateCredentialOffer.mockReset();
+  });
+
+  it("should delegate to the SDK with the offer and issuer metadata", async () => {
+    mockValidateCredentialOffer.mockResolvedValue(undefined);
+
+    await validateCredentialOffer({
+      offer: validOffer,
+      credentialIssuerMetadata,
+    });
+
+    expect(mockValidateCredentialOffer).toHaveBeenCalledWith({
+      config: sdkConfigV1_3,
+      credentialOffer: validOffer,
+      credentialIssuerMetadata,
+    });
+  });
+
+  it("should throw InvalidCredentialOfferError when the SDK rejects with CredentialOfferError", async () => {
+    const { CredentialOfferError } = jest.requireActual(
+      "@pagopa/io-wallet-oid4vci"
+    );
+    mockValidateCredentialOffer.mockRejectedValue(
+      new CredentialOfferError("authorization_server does not match metadata")
+    );
+
+    await expect(
+      validateCredentialOffer({ offer: validOffer, credentialIssuerMetadata })
+    ).rejects.toThrow(InvalidCredentialOfferError);
+  });
+
+  it("should rethrow non-CredentialOfferError errors as-is", async () => {
+    const unexpectedError = new Error("unexpected");
+    mockValidateCredentialOffer.mockRejectedValue(unexpectedError);
+
+    await expect(
+      validateCredentialOffer({ offer: validOffer, credentialIssuerMetadata })
+    ).rejects.toThrow(unexpectedError);
+  });
+});

--- a/src/credential/offer/v1.3.3/index.ts
+++ b/src/credential/offer/v1.3.3/index.ts
@@ -1,8 +1,10 @@
 import type { OfferApi } from "../api";
 import { resolveCredentialOffer } from "./01-resolve-credential-offer";
 import { extractGrantDetails } from "./02-extract-grant-details";
+import { validateCredentialOffer } from "./03-validate-credential-offer";
 
 export const Offer: OfferApi = {
   resolveCredentialOffer,
   extractGrantDetails,
+  validateCredentialOffer,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "esnext",
+    "types": ["jest", "node"],
     "verbatimModuleSyntax": true,
     "moduleSuffixes": [".ios", ".android", ".native", ""]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,7 +1936,7 @@
     "@babel/parser" "^7.28.6"
     "@babel/types" "^7.28.6"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.27.1", "@babel/traverse@^7.27.3", "@babel/traverse@^7.28.0":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.0.tgz#518aa113359b062042379e333db18380b537e34b"
   integrity sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==
@@ -1980,19 +1980,6 @@
     "@babel/types" "^7.24.5"
     debug "^4.3.1"
     globals "^11.1.0"
-
-"@babel/traverse@^7.25.3", "@babel/traverse@^7.27.1", "@babel/traverse@^7.27.3", "@babel/traverse@^7.28.0":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.0.tgz#518aa113359b062042379e333db18380b537e34b"
-  integrity sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==
-  dependencies:
-    "@babel/code-frame" "^7.27.1"
-    "@babel/generator" "^7.28.0"
-    "@babel/helper-globals" "^7.28.0"
-    "@babel/parser" "^7.28.0"
-    "@babel/template" "^7.27.2"
-    "@babel/types" "^7.28.0"
-    debug "^4.3.1"
 
 "@babel/traverse@^7.28.6", "@babel/traverse@^7.29.0":
   version "7.29.0"
@@ -3018,7 +3005,7 @@
     js-base64 "^3.7.7"
     zod "^3.22.4"
 
-"@pagopa/io-wallet-oauth2@", "@pagopa/io-wallet-oauth2@1.4.2":
+"@pagopa/io-wallet-oauth2@":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oauth2/-/io-wallet-oauth2-1.4.2.tgz#8f034b593111128138ba31f4e688c25ad6ac0115"
   integrity sha512-V+OKHY6Eqo8Uz0NqUftKRlER+MOwsr1wW8q+tKd2XA6Ys3kPrXdvC/Jxy3g5UT3Lqm7dCFK0hx3Qc28qECLPCQ==
@@ -3027,6 +3014,18 @@
     "@openid4vc/utils" "0.4.3"
     "@pagopa/io-wallet-oid-federation" "1.4.2"
     "@pagopa/io-wallet-utils" "1.4.2"
+    js-base64 "^3.7.8"
+    zod "^4.3.6"
+
+"@pagopa/io-wallet-oauth2@1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oauth2/-/io-wallet-oauth2-1.5.2.tgz#1ff9576ee242e0b2ea71a3db484f7376c608b428"
+  integrity sha512-nEmPWRaVmY70l4VDjXAOBHdjLYAlHVT6gkzpAQQ5sS9FhlScDq8qvsV35aabVzqFy+3LaCcgNMeD3LYokD+ccQ==
+  dependencies:
+    "@openid4vc/oauth2" "0.4.3"
+    "@openid4vc/utils" "0.4.3"
+    "@pagopa/io-wallet-oid-federation" "1.5.2"
+    "@pagopa/io-wallet-utils" "1.5.2"
     js-base64 "^3.7.8"
     zod "^4.3.6"
 
@@ -3039,24 +3038,33 @@
     buffer "^6.0.3"
     zod "^4.3.6"
 
-"@pagopa/io-wallet-oid4vci@1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oid4vci/-/io-wallet-oid4vci-1.4.2.tgz#11ffd2032dee53da149e3ccca71d85c007cf837e"
-  integrity sha512-0YjwZGPh3XLZRn1J8iAXN28EHA0Vsv/bZWZIB19FkEXZKYsU4J4KqOaehARYVPgRto0k6BTYWAZWuHUaE75AQA==
+"@pagopa/io-wallet-oid-federation@1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oid-federation/-/io-wallet-oid-federation-1.5.2.tgz#ad94f82967321663ccff824537ef8e05f7fdce91"
+  integrity sha512-SRJpdXT301qFlMGYJ6hYQTG/r306C32cJtUDFv2D3BdG+xJ1vmr4h+SbuwQoZWzhhxSS4TmRsHCsvuxzNCcX/w==
+  dependencies:
+    "@pagopa/io-wallet-utils" ""
+    buffer "^6.0.3"
+    zod "^4.3.6"
+
+"@pagopa/io-wallet-oid4vci@1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oid4vci/-/io-wallet-oid4vci-1.5.2.tgz#5eca0c48a5ae6841c5e0b10244d00928d820b47f"
+  integrity sha512-AwwiGKPuljq9jocT6lyb33X/tFh/wzPKGwKUY2QTIt4noYuA3tYaSb29np3j8ae5hh04dDiCFVA4Hsz9Om/nNg==
   dependencies:
     "@openid4vc/oauth2" "0.4.3"
     "@openid4vc/openid4vci" "0.4.3"
     "@openid4vc/utils" "0.4.3"
-    "@pagopa/io-wallet-oauth2" "1.4.2"
-    "@pagopa/io-wallet-oid-federation" "1.4.2"
-    "@pagopa/io-wallet-oid4vp" "1.4.2"
-    "@pagopa/io-wallet-utils" "1.4.2"
+    "@pagopa/io-wallet-oauth2" "1.5.2"
+    "@pagopa/io-wallet-oid-federation" "1.5.2"
+    "@pagopa/io-wallet-oid4vp" "1.5.2"
+    "@pagopa/io-wallet-utils" "1.5.2"
     zod "^4.3.6"
 
-"@pagopa/io-wallet-oid4vp@1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oid4vp/-/io-wallet-oid4vp-1.4.2.tgz#ce56ac7cf23047fbd896cd18228cb35f48b5ecbc"
-  integrity sha512-dgaDThW9WZhG7mv+V+mpQy7y5EKvd7vEbiI8kwqWNmgKvbgEfYtWeYx6Sruo/UWr2QQs0sCl5ouFjOycBbTv7g==
+"@pagopa/io-wallet-oid4vp@1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oid4vp/-/io-wallet-oid4vp-1.5.2.tgz#2c5b5dadfa4e3f1d844b0c9063ce219745bb017b"
+  integrity sha512-Ld4+h1eXP4YPdZSEbJqgkJZEiAbCI1HwjOih/rTRl63N8onyTjOoSjlTFvwM+NvmUmYCP2TWI/ZGM0iM5O9tFQ==
   dependencies:
     "@openid4vc/oauth2" "0.4.3"
     "@openid4vc/openid4vp" "0.4.3"
@@ -3070,6 +3078,15 @@
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-utils/-/io-wallet-utils-1.4.2.tgz#83baef276b9de19347a7682fe5bdf7954aac6086"
   integrity sha512-KMBc1nFXUyOOvWbQT1AJXgqOCNKh7W01o50lxuSQESUp2xPGvTpLXUcSTjG2TXo7AyumaryrCG+Mx2Dt9aBR5w==
+  dependencies:
+    "@openid4vc/oauth2" "0.4.3"
+    "@openid4vc/utils" "0.4.3"
+    zod "^4.3.6"
+
+"@pagopa/io-wallet-utils@1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-utils/-/io-wallet-utils-1.5.2.tgz#5e68b9300abeb3b18a43f77e02e9a27066ff320a"
+  integrity sha512-i5Rnb+PDi+9mhifn5nVxFkeJLgIBNiLaDVqGV9slxzzYAi3InTtG+UrDb/It6kky2UvK2fHRoGENues4pD1Xfg==
   dependencies:
     "@openid4vc/oauth2" "0.4.3"
     "@openid4vc/utils" "0.4.3"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR adapts `io-react-native-wallet` to SDK version 1.5.2, with changes to the Credential Offer and Issuance APIs.

#### List of Changes

<!--- Describe your changes in detail -->
- Credential Offer: Added a new step, 03-validate-credential-offer, which performs the validation 02-extract-grant-details used to perform, which now requires fetching, through credential issuance utilities, of the offer's isser's EC, which creates an interleaving between the offer and issuance steps :
`01-resolve-credential-offer (Offer) --> 02-extract-grant-details (Offer) --> 01-evaluate-issuer-trust (Issuance) --> 03-validate-credential-offer (Offer)`.
Let me know if it would be better to merge 03-validate-credential-offer into 01-evaluate-issuer-trust.

- Credential Issuance : Extended `01-evaluate-issuer-trust`'s interface to accept a credential-offer-specified authorizationServer field, refined mappers to forward `authorization_servers` from the issuer config (needed for 03-validate-credential-offer) and to prefer the credential-offer-specified authorization server's `oauth_authorization_server` metadata to configure the authorization endpoints, if present. Extended 02-start-user-authorization to forward `scope` and `issuer_state` fields in case of credential-offer-initiated flows.

- Example App : extended offer thunk by adding validation of the offer through the fetched EC.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The changes introduced by this PR will unblock SIW-4035 and WLS-127.
JIRA issue WLS-132.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests have been updated to reflect changes to the API where needed (issuance tests have been left untouched because the newly added parameters are simply forwarded).

The offer and credential thunks in the example app have been updated to perform an issuance from a credential offer QR code. The offer flow can be tested by scanning the following QR Code:

<img width="250" height="250" alt="Image" src="https://github.com/user-attachments/assets/6cad1314-67a5-4b0d-9ffc-0c8941352fd5" />

Unfortunately it was not possible, due to device certificate issues, to test the credential offer thunk from the example app.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

