### PR TITLE
fix: [SIW-4544] Handle catalog credentials without authentic source

### DIFF
--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -115,6 +115,7 @@ export const DigitalCredential = z.object({
   purposes: z.array(z.union([z.string(), CredentialPurpose])),
   issuers: z.array(CredentialIssuer),
   authentic_sources: z.array(AuthenticSource),
+  parent_credentials: z.array(z.string()).optional(),
   formats: z.array(CredentialFormat).optional(),
   // claims: z.array(Claim), // TODO: [SIW-3978] Should we keep claims?
 });

--- a/src/credentials-catalogue/v1.3.3/__tests__/mappers.test.ts
+++ b/src/credentials-catalogue/v1.3.3/__tests__/mappers.test.ts
@@ -38,6 +38,15 @@ describe("mapToCredentialsCatalogue", () => {
           "https://issuer-example.com/.well-known/schemas/education_attendance",
         "schema_uri#integrity": "x",
       },
+      {
+        id: "av+mso_mdoc+eu.europa.ec.av.1",
+        version: "1.3",
+        credential_type: "av",
+        format: "mso_mdoc",
+        docType: "eu.europa.ec.av.1",
+        schema_uri: "https://issuer-example.com/schemas/v1.3.3/av.cddl",
+        "schema_uri#integrity": "y",
+      },
     ],
   };
 
@@ -171,6 +180,45 @@ describe("mapToCredentialsCatalogue", () => {
             },
           ],
         },
+        {
+          version: "1",
+          credential_type: "av",
+          credential_name_l10n_id: "av.name",
+          legal_type: "pub-eaa",
+          validity_info: {
+            max_validity_days: 90,
+            status_methods: ["status_list"],
+            administrative_expiration_user_info: {
+              title_l10n_id: "av.administrative_expiration_user_info.title",
+              description_l10n_id:
+                "av.administrative_expiration_user_info.description",
+            },
+            allowed_states: [
+              {
+                "0x00": "VALID",
+                title_l10n_id: "av.VALID.title",
+                description_l10n_id: "av.VALID.description",
+              },
+            ],
+          },
+          authentication: {
+            user_auth_required: true,
+            min_loa: "substantial",
+            supported_schemes: ["it_wallet"],
+          },
+          domains: ["IDENTITY"],
+          classes: ["IDENTIFICATION_DOCUMENTS"],
+          purposes: ["AGE_VERIFICATION"],
+          issuers: [
+            {
+              id: "issuer-1",
+              organization_name_l10n_id: "org123.organization_name",
+              organization_code: "ORG123",
+              organization_country: "IT",
+            },
+          ],
+          parent_credentials: ["pid"], // Credential without Authentic Source
+        },
       ],
     },
   };
@@ -279,6 +327,50 @@ describe("mapToCredentialsCatalogue", () => {
             schema_uri:
               "https://issuer-example.com/.well-known/schemas/education_attendance",
             "schema_uri#integrity": "x",
+          },
+        ],
+      },
+      {
+        version: "1",
+        credential_type: "av",
+        name_l10n_id: "av.name",
+        legal_type: "pub-eaa",
+        validity_info: {
+          max_validity_days: 90,
+          status_methods: ["status_list"],
+          administrative_expiration_user_info: {
+            title_l10n_id: "av.administrative_expiration_user_info.title",
+            description_l10n_id:
+              "av.administrative_expiration_user_info.description",
+          },
+          allowed_states: [
+            {
+              "0x00": "VALID",
+              title_l10n_id: "av.VALID.title",
+              description_l10n_id: "av.VALID.description",
+            },
+          ],
+        },
+        domains: ["IDENTITY"],
+        classes: ["IDENTIFICATION_DOCUMENTS"],
+        purposes: ["AGE_VERIFICATION"],
+        issuers: [
+          {
+            id: "issuer-1",
+            organization_name_l10n_id: "org123.organization_name",
+            organization_code: "ORG123",
+            organization_country: "IT",
+          },
+        ],
+        parent_credentials: ["pid"],
+        authentic_sources: [],
+        formats: [
+          {
+            configuration_id: "av+mso_mdoc+eu.europa.ec.av.1",
+            format: "mso_mdoc",
+            docType: "eu.europa.ec.av.1",
+            schema_uri: "https://issuer-example.com/schemas/v1.3.3/av.cddl",
+            "schema_uri#integrity": "y",
           },
         ],
       },

--- a/src/credentials-catalogue/v1.3.3/mappers.ts
+++ b/src/credentials-catalogue/v1.3.3/mappers.ts
@@ -65,7 +65,7 @@ export const mapToCredentialsCatalogue = createMapper<
         `Schemas for ${credentialType} must be present in the Schema Registry`
       );
       return schemas.map((schema) => ({
-        configuration_id: schema.id, // TODO: [SIW-3978] Does schema ID corresponds to configuration_id?
+        configuration_id: schema.id, // TODO: [SIW-3978] Fix this, the schema ID does not correspond to configuration_id
         ...schema,
       }));
     };
@@ -87,7 +87,9 @@ export const mapToCredentialsCatalogue = createMapper<
         ({ authentic_sources, credential_name_l10n_id, ...credential }) => ({
           name_l10n_id: credential_name_l10n_id,
           formats: resolveFormats(credential.credential_type),
-          authentic_sources: authentic_sources.map(resolveAuthSource),
+          authentic_sources: authentic_sources
+            ? authentic_sources.map(resolveAuthSource)
+            : [],
           ...credential,
         })
       ),

--- a/src/credentials-catalogue/v1.3.3/types.ts
+++ b/src/credentials-catalogue/v1.3.3/types.ts
@@ -132,12 +132,10 @@ export const DigitalCredential = z.object({
   classes: z.array(z.string()).optional(),
   purposes: z.array(z.string()),
   issuers: z.array(CredentialIssuer),
-  authentic_sources: z.array(
-    z.object({
-      id: z.string(),
-      dataset_id: z.string(),
-    })
-  ),
+  authentic_sources: z
+    .array(z.object({ id: z.string(), dataset_id: z.string() }))
+    .optional(),
+  parent_credentials: z.array(z.string()).optional(),
 });
 
 const JwtHeader = z.object({


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Made `authentic_sources` optional
- Added optional `parent_credentials`
- Updated test

#### Motivation and Context

This PR updates the validation schema for the Digital Credentials Catalog, allowing credentials without an Authentic Source (see https://github.com/italia/eid-wallet-it-docs/pull/1154). The new field `parent_credentials` has been added as well.

#### How Has This Been Tested?

Ensure it is possible to correctly validate the catalog (1.0 and 1.3) in the example app.