### PR TITLE
fix: [SIW-4547] Correctly extract `verification` from mdoc

### DIFF
--- a/src/mdoc/const.ts
+++ b/src/mdoc/const.ts
@@ -1,1 +1,2 @@
 export const MDOC_DEFAULT_NAMESPACE = "org.iso.18013.5.1";
+export const MDOC_VERIFICATION_IDENTIFIER = "verification";

--- a/src/mdoc/utils.ts
+++ b/src/mdoc/utils.ts
@@ -2,7 +2,7 @@ import { CBOR } from "@pagopa/io-react-native-iso18013";
 import { Verification } from "../sd-jwt/types";
 import type { IssuanceApi } from "../credential/issuance";
 import type { Out } from "../utils/misc";
-import { MDOC_DEFAULT_NAMESPACE } from "./const";
+import { MDOC_VERIFICATION_IDENTIFIER } from "./const";
 
 /**
  * @param namespace The mdoc credential `namespace`
@@ -25,11 +25,12 @@ export const getVerificationFromParsedCredential = (
     IssuanceApi["verifyAndParseCredential"]
   >["parsedCredential"]
 ) => {
-  const verificationKey = getParsedCredentialClaimKey(
-    `${MDOC_DEFAULT_NAMESPACE}.IT`,
-    "verification"
+  const verificationKey = Object.keys(parsedCredential).find((key) =>
+    key.endsWith(MDOC_VERIFICATION_IDENTIFIER)
   );
-  const verification = parsedCredential[verificationKey]?.value;
+  const verification = verificationKey
+    ? parsedCredential[verificationKey]?.value
+    : undefined;
   return verification ? Verification.parse(verification) : undefined;
 };
 
@@ -43,9 +44,11 @@ export const getVerificationFromParsedCredential = (
  */
 export const getVerification = async (token: string) => {
   const issuerSigned = await CBOR.decodeIssuerSigned(token);
-  const namespace = issuerSigned.nameSpaces[`${MDOC_DEFAULT_NAMESPACE}.IT`];
-  const verification = namespace?.find(
-    (x) => x.elementIdentifier === "verification"
+
+  const flattenedClaims = Object.values(issuerSigned.nameSpaces).flat();
+
+  const verification = flattenedClaims?.find(
+    (x) => x.elementIdentifier === MDOC_VERIFICATION_IDENTIFIER
   )?.elementValue;
 
   return verification ? Verification.parse(verification) : undefined;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Modified `getVerificationFromParsedCredential` and `getVerification` (mdoc)

#### Motivation and Context

This PR fixes `getVerificationFromParsedCredential` and `getVerification` for mdoc credentials, by removing the hardcoded namespace that was valid for MDL only. The `verification` claim is now searched across all namespaces.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
