### PR TITLE
chore: [SIW-4573] Omit claims without display property from parsed credential

### DIFF
--- a/src/credential/issuance/api/IssuerConfig.ts
+++ b/src/credential/issuance/api/IssuerConfig.ts
@@ -9,7 +9,7 @@ const DisplayConfig = z.object({
 
 const ClaimConfig = z.object({
   path: z.array(z.union([z.string(), z.number(), z.null()])),
-  display: z.array(DisplayConfig),
+  display: z.array(DisplayConfig).optional(),
 });
 
 const IssuanceErrorSupported = z.object({

--- a/src/credential/issuance/common/06-verify-and-parse-credential.mdoc.ts
+++ b/src/credential/issuance/common/06-verify-and-parse-credential.mdoc.ts
@@ -13,6 +13,12 @@ import type { IssuanceApi, IssuerConfig, ParsedCredential } from "../api";
 type CredentialConf =
   IssuerConfig["credential_configurations_supported"][string];
 
+type ClaimConfig = CredentialConf["claims"][number];
+
+type DisplayableClaim = Omit<ClaimConfig, "display"> & {
+  display: NonNullable<ClaimConfig["display"]>;
+};
+
 type DecodedMDocCredential = Out<typeof verifyMdoc> & {
   issuerSigned: CBOR.IssuerSigned;
 };
@@ -75,7 +81,13 @@ const parseCredentialMDoc = (
     throw new IoWalletError("Missing claims in the credential subject");
   }
 
-  const attrDefinitions = credentialConfig.claims.map<
+  // Claims without display property (such as `iat`, `exp`, `iss`, etc.)
+  // must be ignored as they are not meant to be displayed to the user.
+  const displayableClaims = credentialConfig.claims.filter(
+    (c) => c.display !== undefined
+  ) as DisplayableClaim[];
+
+  const attrDefinitions = displayableClaims.map<
     [string, string, { name: string; locale: string }[]]
   >(({ path: [namespace, attribute], display }) => [
     namespace as string,
@@ -183,7 +195,11 @@ export const verifyAndParseCredentialMDoc: IssuanceApi["verifyAndParseCredential
     issuerConf,
     credential,
     credentialConfigurationId,
-    { credentialCryptoContext, ignoreMissingAttributes },
+    {
+      credentialCryptoContext,
+      ignoreMissingAttributes,
+      includeUndefinedAttributes,
+    },
     x509CertRoot
   ) => {
     if (!x509CertRoot) {
@@ -204,7 +220,7 @@ export const verifyAndParseCredentialMDoc: IssuanceApi["verifyAndParseCredential
       credentialConfig,
       decoded,
       ignoreMissingAttributes,
-      ignoreMissingAttributes
+      includeUndefinedAttributes
     );
 
     const { signed, validUntil } =

--- a/src/credential/issuance/common/06-verify-and-parse-credential.sdjwt.ts
+++ b/src/credential/issuance/common/06-verify-and-parse-credential.sdjwt.ts
@@ -18,6 +18,12 @@ import type { IssuanceApi, IssuerConfig, ParsedCredential } from "../api";
 type CredentialConf =
   IssuerConfig["credential_configurations_supported"][string];
 
+type ClaimConfig = CredentialConf["claims"][number];
+
+type ClaimsWithDisplay = Omit<ClaimConfig, "display"> & {
+  display: NonNullable<ClaimConfig["display"]>;
+};
+
 /**
  * Parse a Sd-Jwt credential according to the issuer configuration
  * @param credentialConfig - the list of supported credentials, as defined in the issuer configuration with their claims metadata
@@ -32,7 +38,11 @@ const parseCredentialSdJwt = (
   ignoreMissingAttributes: boolean = false,
   includeUndefinedAttributes: boolean = false
 ): ParsedCredential => {
-  const claimsMetadata = credentialConfig.claims || [];
+  // Claims without display property (such as `iat`, `exp`, `iss`, etc.)
+  // must be ignored as they are not meant to be displayed to the user.
+  const claimsMetadata = (credentialConfig.claims || []).filter(
+    (c) => c.display !== undefined
+  ) as ClaimsWithDisplay[];
 
   // Check that all mandatory attributes defined in the issuer configuration are present in the credential
   if (!ignoreMissingAttributes) {

--- a/src/credential/issuance/common/06-verify-and-parse-credential.sdjwt.ts
+++ b/src/credential/issuance/common/06-verify-and-parse-credential.sdjwt.ts
@@ -20,7 +20,7 @@ type CredentialConf =
 
 type ClaimConfig = CredentialConf["claims"][number];
 
-type ClaimsWithDisplay = Omit<ClaimConfig, "display"> & {
+type DisplayableClaim = Omit<ClaimConfig, "display"> & {
   display: NonNullable<ClaimConfig["display"]>;
 };
 
@@ -40,15 +40,15 @@ const parseCredentialSdJwt = (
 ): ParsedCredential => {
   // Claims without display property (such as `iat`, `exp`, `iss`, etc.)
   // must be ignored as they are not meant to be displayed to the user.
-  const claimsMetadata = (credentialConfig.claims || []).filter(
+  const displayableClaims = (credentialConfig.claims || []).filter(
     (c) => c.display !== undefined
-  ) as ClaimsWithDisplay[];
+  ) as DisplayableClaim[];
 
   // Check that all mandatory attributes defined in the issuer configuration are present in the credential
   if (!ignoreMissingAttributes) {
     const missingPaths: string[] = [];
     const rootKeysToVerify = new Set(
-      claimsMetadata
+      displayableClaims
         .map((c) => c.path[0])
         .filter((p): p is string => typeof p === "string")
     );
@@ -74,7 +74,7 @@ const parseCredentialSdJwt = (
   const getDisplayNames = (
     path: (string | number | null)[]
   ): Record<string, string> | undefined => {
-    const match = claimsMetadata.find((c) => isPathEqual(c.path, path));
+    const match = displayableClaims.find((c) => isPathEqual(c.path, path));
     if (!match) return undefined;
 
     const nameMap: Record<string, string> = {};
@@ -109,7 +109,7 @@ const parseCredentialSdJwt = (
 
     // Identify unique keys in config at this level
     const configKeysAtThisLevel: (string | number)[] = [];
-    for (const claim of claimsMetadata) {
+    for (const claim of displayableClaims) {
       // Check if the claim path starts with the current path
       if (isPrefixOf(currentPath, claim.path)) {
         const nextPart = claim.path[currentPath.length];

--- a/src/credential/issuance/v1.3.3/__tests__/06-verify-and-parse-credential.test.ts
+++ b/src/credential/issuance/v1.3.3/__tests__/06-verify-and-parse-credential.test.ts
@@ -39,6 +39,12 @@ describe("verifyAndParseCredential", () => {
         scope: "PersonIdentificationData",
         claims: [
           {
+            path: ["iss"],
+          },
+          {
+            path: ["iat"],
+          },
+          {
             path: ["given_name"],
             display: [
               { locale: "it-IT", name: "Nome" },


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Filtered `credentialConfig.claims` in mdoc and sd-jwt parsers.

#### Motivation and Context

This PR implements https://github.com/italia/eid-wallet-it-docs/pull/1167 and properly handles the now optional `display` property in each claim definition. 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
