### PR TITLE
fix: [SIW-0000] Remove fallback for optional claims[i].display

### DIFF
--- a/src/credential/issuance/v1.3.3/__tests__/mappers.test.ts
+++ b/src/credential/issuance/v1.3.3/__tests__/mappers.test.ts
@@ -76,7 +76,6 @@ describe("mapToIssuerConfig", () => {
             },
             {
               path: ["family_name"],
-              display: [],
             },
           ],
         },

--- a/src/credential/issuance/v1.3.3/mappers.ts
+++ b/src/credential/issuance/v1.3.3/mappers.ts
@@ -25,7 +25,7 @@ const mapCredentialConfigurationsSupported = (
         claims:
           config.credential_metadata.claims?.map((claim) => ({
             path: claim.path,
-            display: claim.display ?? [],
+            display: claim.display,
           })) ?? [],
       };
       return acc;


### PR DESCRIPTION
#### Motivation and Context

Remove the empty array fallback when the `display` field is absent, otherwise the claim is not skipped during parsing.
