### PR TITLE
fix: [SIW-4615] Extract user_information from data capabilities (credentials catalog 1.3)

### DIFF
--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -63,6 +63,7 @@ const AuthenticSource = z.object({
   homepage_uri: z.string().optional(),
   logo_uri: z.string().optional(),
   user_information: z.string().optional(),
+  user_information_l10n_id: z.string().optional(),
 });
 export type AuthenticSource = z.infer<typeof AuthenticSource>;
 

--- a/src/credentials-catalogue/v1.3.3/__tests__/mappers.test.ts
+++ b/src/credentials-catalogue/v1.3.3/__tests__/mappers.test.ts
@@ -66,7 +66,16 @@ describe("mapToCredentialsCatalogue", () => {
           contacts: ["info@source-org.example.com"],
           policy_uri: "https://source-org.example.com/privacy",
         },
-        data_capabilities: [],
+        data_capabilities: [
+          {
+            dataset_id: "dataset-1",
+            available_claims: [],
+            data_origin_l10n_id: "source_dataorigin.name",
+            integration_method: "",
+            intended_purposes: [],
+            user_information_l10n_id: "source_userinfo.name",
+          },
+        ],
       },
     ],
   };
@@ -317,6 +326,7 @@ describe("mapToCredentialsCatalogue", () => {
             organization_type: "public",
             contacts: ["info@source-org.example.com"],
             homepage_uri: "https://source-org.example.com",
+            user_information_l10n_id: "source_userinfo.name",
           },
         ],
         formats: [

--- a/src/credentials-catalogue/v1.3.3/mappers.ts
+++ b/src/credentials-catalogue/v1.3.3/mappers.ts
@@ -42,6 +42,7 @@ export const mapToCredentialsCatalogue = createMapper<
 
     const resolveAuthSource = ({
       id,
+      dataset_id,
     }: {
       id: string;
       dataset_id: string;
@@ -50,10 +51,14 @@ export const mapToCredentialsCatalogue = createMapper<
       assert(as, `AS ${id} must be present in the Authentic Source Registry`);
       const { ipa_code, organization_name_l10n_id, ...rest } =
         as.organization_info;
+      const dataCapability = as.data_capabilities.find(
+        (dc) => dc.dataset_id === dataset_id
+      );
       return {
         id,
         organization_name_l10n_id,
         organization_code: ipa_code,
+        user_information_l10n_id: dataCapability?.user_information_l10n_id,
         ...rest,
       };
     };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Extract user_information from the Authentic Source's data capabilities

#### Motivation and Context

This PR fixes an issue the causes the user information to be omitted in the mapped v1.3 catalog. Without `user_information`, it is not possible to display the introduction content to users that request a specific credential.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
