### PR TITLE
fix: [SIW-0000] improve certificate chain validation by handling extraneous certs

### DIFF
--- a/src/credential/presentation/v1.3.3/04-verify-certificate-chain.ts
+++ b/src/credential/presentation/v1.3.3/04-verify-certificate-chain.ts
@@ -20,13 +20,21 @@ export const verifyAuthRequestCertificateChain: RemotePresentationApi["verifyAut
 
     const requestObject = decode(requestObjectJwt);
 
-    const certChain = requestObject.protectedHeader.x5c;
+    const x5c = requestObject.protectedHeader.x5c;
 
-    if (!certChain) {
+    if (!x5c) {
       throw new MissingX509CertsError(
         "No certificate chain (x5c) found in the Request Object"
       );
     }
+
+    // The native validator expects the chain to include the leaf and any
+    // intermediates, excluding the trust anchor (supplied separately as
+    // `caRootCert`). Some RPs include the anchor as the last entry of x5c,
+    // which must be stripped or the native validator (notably on iOS) treats
+    // it as an extraneous/unexpected trailing certificate and fails.
+    const certChain =
+      x5c.length > 1 && x5c.at(-1) === caRootCert ? x5c.slice(0, -1) : x5c;
 
     const validationResult = await verifyCertificateChain(
       certChain,
@@ -41,7 +49,7 @@ export const verifyAuthRequestCertificateChain: RemotePresentationApi["verifyAut
       );
 
       throw new X509ValidationError(
-        "X.509 certificate chain validation failed"
+        `X.509 certificate chain validation failed. Status: ${validationResult.validationStatus}. Error: ${validationResult.errorMessage}`
       );
     }
 


### PR DESCRIPTION
#### List of Changes

Strip the trust anchor certificate from the `x5c` chain before calling the native X.509 validator in `verifyAuthRequestCertificateChain` (remote presentation flow), if the last entry of `x5c` matches `caRootCert`. Also propagate the native `validationStatus`/`errorMessage` into the thrown `X509ValidationError` message instead of a generic fixed string.

#### Motivation and Context

RPs may legitimately include the self-signed root/trust anchor as the last certificate in `x5c` (RFC 7515 doesn't forbid it). The iOS native validator (`X509VerificationUtils.swift`) expects the input chain to *exclude* the anchor and fails with `"Certificate chain is longer than necessary. Extraneous certificate found at input index 1."` when it's present;  this only reproduces on iOS since Android's `CertPathValidator` tolerates chains with or without the anchor. This surfaced as a generic `UNTRUSTED_RP` / `"X.509 certificate chain validation failed"` error during remote presentation with no actionable detail, since the native `validationStatus` was being discarded before reaching the thrown error.

The equivalent anchor-stripping normalization already existed in the federation trust-chain path (`trust/common/verify-chain.ts`) but was missing from the remote-presentation path.