### PR TITLE
chore: [SIW-0000] Add  `getStatusListEntry` to public API

### DIFF
--- a/src/credential/status/api/status-list.ts
+++ b/src/credential/status/api/status-list.ts
@@ -73,4 +73,18 @@ export interface StatusListApi {
     rawStatus: string;
     status: string;
   };
+
+  /**
+   * Extracts the status list entry from a raw credential, i.e. the object containing `uri` and `ìdx`.
+   *
+   * This method **does not perform any HTTP request** to fetch the list. Use {@link get} or {@link getByUri} instead to fetch it.
+   * @since 1.3.3
+   * @param credential The raw credential
+   * @param format The credential format
+   * @returns The status list entry extracted from the credential
+   */
+  getStatusListEntry(
+    credential: string,
+    format: CredentialFormat
+  ): Promise<{ idx: number; uri: string }>;
 }

--- a/src/credential/status/v1.3.3/01-status-list.ts
+++ b/src/credential/status/v1.3.3/01-status-list.ts
@@ -6,13 +6,12 @@ import {
 } from "@sd-jwt/jwt-status-list";
 import { IoWalletError } from "../../../utils/errors";
 import { hasStatusOrThrow } from "../../../utils/misc";
-import type { CredentialFormat } from "../../../credential/issuance/api";
 import type { StatusListApi } from "../api/status-list";
 
-const getStatusListEntry = async (
-  credential: string,
-  format: CredentialFormat
-): Promise<StatusListEntry> => {
+export const getStatusListEntry: StatusListApi["getStatusListEntry"] = async (
+  credential,
+  format
+) => {
   let statusListEntry: StatusListEntry | undefined;
 
   if (format === "mso_mdoc") {

--- a/src/credential/status/v1.3.3/index.ts
+++ b/src/credential/status/v1.3.3/index.ts
@@ -1,5 +1,9 @@
 import type { CredentialStatusApi } from "../api";
-import { getStatusList, getStatusListByUri } from "./01-status-list";
+import {
+  getStatusList,
+  getStatusListByUri,
+  getStatusListEntry,
+} from "./01-status-list";
 import { verifyAndParseStatusList } from "./02-verify-and-parse-status-list";
 import { getStatus } from "./03-get-status";
 
@@ -13,5 +17,6 @@ export const CredentialStatus: CredentialStatusApi = {
     getByUri: getStatusListByUri,
     verifyAndParse: verifyAndParseStatusList,
     getStatus,
+    getStatusListEntry,
   },
 };

--- a/src/sd-jwt/types.ts
+++ b/src/sd-jwt/types.ts
@@ -14,7 +14,7 @@ const StatusAssertion = z.object({
 });
 
 const StatusList = z.object({
-  idx: z.string(),
+  idx: z.number(),
   uri: z.string(),
 });
 


### PR DESCRIPTION

#### Motivation and Context

This PR exposes `getStatusListEntry` so it is possible to extract the status list reference—`uri` and `idx`—from a raw credential, without fetching it. This allows for a finer control when fetching is postponed.