### PR TITLE
chore: [SIW-4670] Use the new `key-attestations` endpoint

### DIFF
--- a/openapi/wallet-provider.yaml
+++ b/openapi/wallet-provider.yaml
@@ -380,13 +380,13 @@ components:
         hardware_key_tag:
           minLength: 1
           type: string
+        is_renewal:
+          type: boolean
+          default: false
       example:
         challenge: string
         key_attestation: string
         hardware_key_tag: string
-        is_renewal:
-          type: boolean
-          default: false
     CreateWalletAttestationBody:
       required:
       - assertion

--- a/openapi/wallet-provider.yaml
+++ b/openapi/wallet-provider.yaml
@@ -58,8 +58,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/CreateWalletAttestationBody"
-            example:
-              assertion: eyJhbGciOiJFUzI1NiIsImtpZCI6InZiZVhKa3NNNDV4cGh0QU5uQ2lHNm1DeXVVNGpmR056b3BHdUt2b2dnOWMiLCJ0eXAiOiJ3YXIrand0In0.eyJpc3MiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9pbnN0YW5jZS92YmVYSmtzTTQ1eHBodEFObkNpRzZtQ3l1VTRqZkdOem9wR3VLdm9nZzljIiwic3ViIjoiaHR0cHM6Ly93YWxsZXQtcHJvdmlkZXIuZXhhbXBsZS5vcmcvIiwiY2hhbGxlbmdlIjoiNmVjNjkzMjQtNjBhOC00ZTViLWE2OTctYTc2NmQ4NTc5MGVhIiwiaGFyZHdhcmVfc2lnbmF0dXJlIjoiS29aSWh2Y05BUWNDb0lBd2dBSUIuLi5yZWRhY3RlZCIsImludGVncml0eV9hc3NlcnRpb24iOiJvMk5tYlhSdllYQndiR1V0WVhCd1lYLi4ucmVkYWN0ZWQiLCJoYXJkd2FyZV9rZXlfdGFnIjoiV1FoeUR5bUZLc1A5NWlGcXB6ZEVEV1c0bDdhVm5hMkZuNEpDZVdIWXRiVT0iLCJjbmYiOnsiandrIjp7ImNydiI6IlAtMjU2Iiwia3R5IjoiRUMiLCJ4IjoiNEhOcHRJLXhyMnBqeVJKS0dNbno0V21kblFEX3VKU3E0Ujk1Tmo5OGI0NCIsInkiOiJMSVpuU0IzOXZGSmhZZ1MzazdqWEU0cjMtQ29HRlF3WnRQQklScXBObHJnIiwia2lkIjoidmJlWEprc000NXhwaHRBTm5DaUc2bUN5dVU0amZHTnpvcEd1S3ZvZ2c5YyJ9fSwidnBfZm9ybWF0c19zdXBwb3J0ZWQiOnsiand0X3ZjX2pzb24iOnsiYWxnX3ZhbHVlc19zdXBwb3J0ZWQiOlsiRVMyNTZLIiwiRVMzODQiXX0sImp3dF92cF9qc29uIjp7ImFsZ192YWx1ZXNfc3VwcG9ydGVkIjpbIkVTMjU2SyIsIkVkRFNBIl19fSwiaWF0IjoxNjg2NjQ1MTE1LCJleHAiOjE2ODY2NTIzMTV9.F32bisVth4eDdGxDjB9ByENT-oZLtSY_89uwTSePo2GMEKaeEedpXZE_9mrX7t0_Fmc5m6LNVvIIBqotqsYJYQ
       responses:
         "200":
           description: List of generated Wallet Attestations
@@ -103,11 +101,11 @@ paths:
       description: Retrieve a Wallet Instance status
       operationId: getWalletInstanceStatus
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Wallet Instance status successfully retrieved
@@ -128,18 +126,16 @@ paths:
         If the Wallet Instance is already revoked, the operation will succeed.
       operationId: setWalletInstanceStatus
       parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/SetWalletInstanceStatusData"
-            example:
-              status: REVOKED
       responses:
         "204":
           description: Wallet Instance status successfully set
@@ -175,16 +171,13 @@ paths:
       operationId: isFiscalCodeWhitelisted
       responses:
         "200":
-          description: Returned when no issues were found in either case (fiscal code
+          description:
+            Returned when no issues were found in either case (fiscal code
             whitelisted, or not)
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/WhitelistedFiscalCodeData"
-              example:
-                whitelisted: true
-                whitelistedAt: string
-                fiscalCode: string
         "500":
           $ref: "#/components/responses/InternalServerError"
         "503":
@@ -257,21 +250,58 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+
+  "/key-attestations":
+    post:
+      summary: CreateKeyAttestation
+      description: Create and return a Key Attestation
+      operationId: createKeyAttestation
+      parameters:
+      - name: Content-Type
+        in: header
+        schema:
+          type: string
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              $ref: "#/components/schemas/CreateKeyAttestationBody"
+      responses:
+        "200":
+          description: Key Attestation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/KeyAttestation"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/UnprocessableContent"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 components:
   schemas:
     SetWalletInstanceStatusData:
       required:
-      - status
+        - status
       type: object
       properties:
         status:
           enum:
-          - REVOKED
+            - REVOKED
           type: string
+      example:
+        status: REVOKED
     WalletInstanceData:
       required:
-      - id
-      - is_revoked
+        - id
+        - is_revoked
       type: object
       properties:
         id:
@@ -287,14 +317,14 @@ components:
         revocation_reason: CERTIFICATE_REVOKED_BY_ISSUER
     NonceDetailView:
       required:
-      - nonce
+        - nonce
       type: object
       properties:
         nonce:
           type: string
     WalletAttestationsView:
       required:
-      - wallet_attestations
+        - wallet_attestations
       type: object
       properties:
         wallet_attestations:
@@ -303,20 +333,20 @@ components:
           type: array
           items:
             required:
-            - format
-            - wallet_attestation
+              - format
+              - wallet_attestation
             type: object
             properties:
               format:
                 enum:
-                - jwt
-                - dc+sd-jwt
+                  - jwt
+                  - dc+sd-jwt
                 type: string
               wallet_attestation:
                 type: string
     WalletInstanceAttestation:
       required:
-      - wallet_instance_attestation
+        - wallet_instance_attestation
       type: object
       properties:
         wallet_instance_attestation:
@@ -325,7 +355,7 @@ components:
         wallet_instance_attestation: string
     WalletUnitAttestation:
       required:
-      - wallet_unit_attestation
+        - wallet_unit_attestation
       type: object
       properties:
         wallet_unit_attestation:
@@ -334,9 +364,9 @@ components:
         wallet_unit_attestation: string
     CreateWalletInstanceBody:
       required:
-      - challenge
-      - key_attestation
-      - hardware_key_tag
+        - challenge
+        - key_attestation
+        - hardware_key_tag
       type: object
       properties:
         challenge:
@@ -350,6 +380,10 @@ components:
         hardware_key_tag:
           minLength: 1
           type: string
+      example:
+        challenge: string
+        key_attestation: string
+        hardware_key_tag: string
         is_renewal:
           type: boolean
           default: false
@@ -363,6 +397,8 @@ components:
           type: string
           format: binary
           example: eyJhbGciOiJFUzI1NiIsImtpZCI6InZiZVhKa3NNNDV4cGh0QU5uQ2lHNm1DeXVVNGpmR056b3BHdUt2b2dnOWMiLCJ0eXAiOiJ3YXIrand0In0.eyJpc3MiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9pbnN0YW5jZS92YmVYSmtzTTQ1eHBodEFObkNpRzZtQ3l1VTRqZkdOem9wR3VLdm9nZzljIiwic3ViIjoiaHR0cHM6Ly93YWxsZXQtcHJvdmlkZXIuZXhhbXBsZS5vcmcvIiwiY2hhbGxlbmdlIjoiNmVjNjkzMjQtNjBhOC00ZTViLWE2OTctYTc2NmQ4NTc5MGVhIiwiaGFyZHdhcmVfc2lnbmF0dXJlIjoiS29aSWh2Y05BUWNDb0lBd2dBSUIuLi5yZWRhY3RlZCIsImludGVncml0eV9hc3NlcnRpb24iOiJvMk5tYlhSdllYQndiR1V0WVhCd1lYLi4ucmVkYWN0ZWQiLCJoYXJkd2FyZV9rZXlfdGFnIjoiV1FoeUR5bUZLc1A5NWlGcXB6ZEVEV1c0bDdhVm5hMkZuNEpDZVdIWXRiVT0iLCJjbmYiOnsiandrIjp7ImNydiI6IlAtMjU2Iiwia3R5IjoiRUMiLCJ4IjoiNEhOcHRJLXhyMnBqeVJKS0dNbno0V21kblFEX3VKU3E0Ujk1Tmo5OGI0NCIsInkiOiJMSVpuU0IzOXZGSmhZZ1MzazdqWEU0cjMtQ29HRlF3WnRQQklScXBObHJnIiwia2lkIjoidmJlWEprc000NXhwaHRBTm5DaUc2bUN5dVU0amZHTnpvcEd1S3ZvZ2c5YyJ9fSwidnBfZm9ybWF0c19zdXBwb3J0ZWQiOnsiand0X3ZjX2pzb24iOnsiYWxnX3ZhbHVlc19zdXBwb3J0ZWQiOlsiRVMyNTZLIiwiRVMzODQiXX0sImp3dF92cF9qc29uIjp7ImFsZ192YWx1ZXNfc3VwcG9ydGVkIjpbIkVTMjU2SyIsIkVkRFNBIl19fSwiaWF0IjoxNjg2NjQ1MTE1LCJleHAiOjE2ODY2NTIzMTV9.F32bisVth4eDdGxDjB9ByENT-oZLtSY_89uwTSePo2GMEKaeEedpXZE_9mrX7t0_Fmc5m6LNVvIIBqotqsYJYQ
+      example:
+        assertion: eyJhbGciOiJFUzI1NiIsImtpZCI6InZiZVhKa3NNNDV4cGh0QU5uQ2lHNm1DeXVVNGpmR056b3BHdUt2b2dnOWMiLCJ0eXAiOiJ3YXIrand0In0.eyJpc3MiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9pbnN0YW5jZS92YmVYSmtzTTQ1eHBodEFObkNpRzZtQ3l1VTRqZkdOem9wR3VLdm9nZzljIiwic3ViIjoiaHR0cHM6Ly93YWxsZXQtcHJvdmlkZXIuZXhhbXBsZS5vcmcvIiwiY2hhbGxlbmdlIjoiNmVjNjkzMjQtNjBhOC00ZTViLWE2OTctYTc2NmQ4NTc5MGVhIiwiaGFyZHdhcmVfc2lnbmF0dXJlIjoiS29aSWh2Y05BUWNDb0lBd2dBSUIuLi5yZWRhY3RlZCIsImludGVncml0eV9hc3NlcnRpb24iOiJvMk5tYlhSdllYQndiR1V0WVhCd1lYLi4ucmVkYWN0ZWQiLCJoYXJkd2FyZV9rZXlfdGFnIjoiV1FoeUR5bUZLc1A5NWlGcXB6ZEVEV1c0bDdhVm5hMkZuNEpDZVdIWXRiVT0iLCJjbmYiOnsiandrIjp7ImNydiI6IlAtMjU2Iiwia3R5IjoiRUMiLCJ4IjoiNEhOcHRJLXhyMnBqeVJKS0dNbno0V21kblFEX3VKU3E0Ujk1Tmo5OGI0NCIsInkiOiJMSVpuU0IzOXZGSmhZZ1MzazdqWEU0cjMtQ29HRlF3WnRQQklScXBObHJnIiwia2lkIjoidmJlWEprc000NXhwaHRBTm5DaUc2bUN5dVU0amZHTnpvcEd1S3ZvZ2c5YyJ9fSwidnBfZm9ybWF0c19zdXBwb3J0ZWQiOnsiand0X3ZjX2pzb24iOnsiYWxnX3ZhbHVlc19zdXBwb3J0ZWQiOlsiRVMyNTZLIiwiRVMzODQiXX0sImp3dF92cF9qc29uIjp7ImFsZ192YWx1ZXNfc3VwcG9ydGVkIjpbIkVTMjU2SyIsIkVkRFNBIl19fSwiaWF0IjoxNjg2NjQ1MTE1LCJleHAiOjE2ODY2NTIzMTV9.F32bisVth4eDdGxDjB9ByENT-oZLtSY_89uwTSePo2GMEKaeEedpXZE_9mrX7t0_Fmc5m6LNVvIIBqotqsYJYQ
     CreateWalletInstanceAttestationBody:
       type: string
       minLength: 1
@@ -370,12 +406,24 @@ components:
     CreateWalletUnitAttestationBody:
       type: string
       minLength: 1
+    CreateKeyAttestationBody:
+      type: string
+      minLength: 1
+    KeyAttestation:
+      required:
+      - key_attestation
+      type: object
+      properties:
+        key_attestation:
+          type: string
+      example:
+        key_attestation: string
     RevocationReason:
       enum:
-      - CERTIFICATE_REVOKED_BY_ISSUER
-      - NEW_WALLET_INSTANCE_CREATED
-      - WALLET_INSTANCE_RENEWAL
-      - REVOKED_BY_USER
+        - CERTIFICATE_REVOKED_BY_ISSUER
+        - NEW_WALLET_INSTANCE_CREATED
+        - WALLET_INSTANCE_RENEWAL
+        - REVOKED_BY_USER
       type: string
     ProblemJson:
       type: object
@@ -397,7 +445,8 @@ components:
           exclusiveMaximum: true
           minimum: 100
           type: integer
-          description: The HTTP status code generated by the origin server for this
+          description:
+            The HTTP status code generated by the origin server for this
             occurrence of the problem.
           format: int32
           example: 500
@@ -409,18 +458,20 @@ components:
           example: There was an error processing the request
         instance:
           type: string
-          description: An absolute URI that identifies the specific occurrence of
+          description:
+            An absolute URI that identifies the specific occurrence of
             the problem. It may or may not yield further information if dereferenced.
           format: uri
     WhitelistedFiscalCodeData:
       required:
-      - whitelisted
-      - fiscalCode
+        - whitelisted
+        - fiscalCode
       type: object
       properties:
         whitelisted:
           type: boolean
-          description: Boolean value that specifies whether the tax code is whitelisted
+          description:
+            Boolean value that specifies whether the tax code is whitelisted
             or not.
         whitelistedAt:
           type: string
@@ -430,6 +481,10 @@ components:
         fiscalCode:
           type: string
           description: The fiscal code, the same one passed in input.
+      example:
+        whitelisted: true
+        whitelistedAt: string
+        fiscalCode: string
   responses:
     Forbidden:
       description: The server understands the request but refuses to authorize it

--- a/src/wallet-unit-attestation/v1.3.3/__tests__/issuing.test.ts
+++ b/src/wallet-unit-attestation/v1.3.3/__tests__/issuing.test.ts
@@ -43,7 +43,7 @@ const createMockFetch = () => {
   );
 
   appFetch.mockResolvedValueOnce(
-    new Response(JSON.stringify({ wallet_unit_attestation: "wua" }), {
+    new Response(JSON.stringify({ key_attestation: "wua" }), {
       status: 200,
       headers: { "content-type": "application/json" },
     })

--- a/src/wallet-unit-attestation/v1.3.3/issuing.ts
+++ b/src/wallet-unit-attestation/v1.3.3/issuing.ts
@@ -127,7 +127,7 @@ export const getAttestation: WalletUnitAttestationSupportedApi["getAttestation"]
     );
 
     const response = await api
-      .post("/wallet-unit-attestations", {
+      .post("/key-attestations", {
         header: {
           "Content-Type": "text/plain",
         },

--- a/src/wallet-unit-attestation/v1.3.3/issuing.ts
+++ b/src/wallet-unit-attestation/v1.3.3/issuing.ts
@@ -137,11 +137,11 @@ export const getAttestation: WalletUnitAttestationSupportedApi["getAttestation"]
 
     Logger.log(
       LogLevel.DEBUG,
-      `Obtained Wallet Unit Attestation: ${response.wallet_unit_attestation}`
+      `Obtained Wallet Unit Attestation: ${response.key_attestation}`
     );
 
     return {
       format: "jwt",
-      attestation: response.wallet_unit_attestation,
+      attestation: response.key_attestation,
     };
   };

--- a/src/wallet-unit-attestation/v1.3.3/types.ts
+++ b/src/wallet-unit-attestation/v1.3.3/types.ts
@@ -17,5 +17,5 @@ export type WalletUnitAttestationResponse = z.infer<
   typeof WalletUnitAttestationResponse
 >;
 export const WalletUnitAttestationResponse = z.object({
-  wallet_unit_attestation: z.string(),
+  key_attestation: z.string(),
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Updated the Wallet Provider OpenAPI yaml 
- Renamed `wallet-unit-attestations` endpoint to `key-attestations`


#### How Has This Been Tested?

Test the credentials issuance and ensure everything works as expected.

