### PR TITLE
chore: properly handle null values in remote presentation `startFlowFromQR`

### DIFF
--- a/src/credential/presentation/api/types.ts
+++ b/src/credential/presentation/api/types.ts
@@ -10,14 +10,14 @@ export type PresentationParams = z.infer<typeof PresentationParams>;
 export const PresentationParams = z.object({
   client_id: z.string().nonempty(),
   request: z.string().optional(),
-  request_uri: z.string().url().optional(),
+  request_uri: z.url().optional(),
   request_uri_method: z.enum(["get", "post"]).optional(),
   state: z.string().optional(),
 });
 
 export type WalletMetadata = z.infer<typeof WalletMetadata>;
 export const WalletMetadata = z.object({
-  authorization_endpoint: z.string().url(),
+  authorization_endpoint: z.url(),
   client_id_prefixes_supported: z.array(z.string()).optional(),
   client_id_schemes_supported: z.array(z.string()).optional(),
   request_object_signing_alg_values_supported: z.array(z.string()).optional(),

--- a/src/credential/presentation/v1.4.6/01-start-flow.ts
+++ b/src/credential/presentation/v1.4.6/01-start-flow.ts
@@ -8,16 +8,20 @@ import { InvalidQRCodeError } from "../common/errors";
 export const startFlowFromQR: RemotePresentationApi["startFlowFromQR"] = (
   params,
 ) => {
-  const parsed = PresentationParams.safeParse(params);
+  const nonNullParams = Object.fromEntries(
+    Object.entries(params).filter(([_, value]) => value !== null)
+  );
+  const parsed = PresentationParams.safeParse({
+    ...nonNullParams,
+    request_uri_method: nonNullParams.request_uri_method ?? "get",
+  });
 
   if (!parsed.success) {
     throw new InvalidQRCodeError(parsed.error.message);
   }
 
   try {
-    const validatedParams = validateAuthorizationRequestParams(parsed.data);
-
-    return validatedParams;
+    return validateAuthorizationRequestParams(parsed.data);
   } catch (e) {
     throw new InvalidQRCodeError(e instanceof Error ? e.message : String(e));
   }

--- a/src/credential/presentation/v1.4.6/01-start-flow.ts
+++ b/src/credential/presentation/v1.4.6/01-start-flow.ts
@@ -9,7 +9,7 @@ export const startFlowFromQR: RemotePresentationApi["startFlowFromQR"] = (
   params,
 ) => {
   const nonNullParams = Object.fromEntries(
-    Object.entries(params).filter(([_, value]) => value !== null)
+    Object.entries(params).filter(([_, value]) => value !== null),
   );
   const parsed = PresentationParams.safeParse({
     ...nonNullParams,

--- a/src/credential/presentation/v1.4.6/__tests__/01-start-flow.test.ts
+++ b/src/credential/presentation/v1.4.6/__tests__/01-start-flow.test.ts
@@ -1,0 +1,54 @@
+import { startFlowFromQR } from "../01-start-flow";
+import { InvalidQRCodeError } from "../../common/errors";
+
+describe("startFlowFromQR", () => {
+  const client_id = "client123";
+  const request_uri = "https://rp.example.com/request";
+
+  it("validates a request URI QR code and defaults its method to get", () => {
+    expect(
+      startFlowFromQR({ client_id, request_uri, state: "state123" }),
+    ).toEqual({
+      client_id,
+      request_uri,
+      request_uri_method: "get",
+      state: "state123",
+    });
+  });
+
+  it("preserves an explicit request URI method", () => {
+    expect(
+      startFlowFromQR({ client_id, request_uri, request_uri_method: "post" }),
+    ).toEqual({ client_id, request_uri, request_uri_method: "post" });
+  });
+
+  it.each([
+    ["a missing client ID", { request_uri }],
+    ["an invalid request URI", { client_id, request_uri: "not-a-url" }],
+    [
+      "null request parameters",
+      { client_id, request: null, request_uri: null },
+    ],
+    [
+      "both a request and request URI",
+      { client_id, request: "request", request_uri },
+    ],
+  ])("throws InvalidQRCodeError for %s", (_, params) => {
+    expect(() => startFlowFromQR(params)).toThrow(InvalidQRCodeError);
+  });
+
+  it.each([null, undefined])(
+    "handles optional (%s) values",
+    (value) => {
+      expect(
+        startFlowFromQR({
+          client_id,
+          request_uri,
+          request_uri_method: value,
+          request: value,
+          state: value
+        })
+      ).toEqual({ client_id, request_uri, request_uri_method: "get" });
+    },
+  );
+});

--- a/src/credential/presentation/v1.4.6/__tests__/01-start-flow.test.ts
+++ b/src/credential/presentation/v1.4.6/__tests__/01-start-flow.test.ts
@@ -37,18 +37,15 @@ describe("startFlowFromQR", () => {
     expect(() => startFlowFromQR(params)).toThrow(InvalidQRCodeError);
   });
 
-  it.each([null, undefined])(
-    "handles optional (%s) values",
-    (value) => {
-      expect(
-        startFlowFromQR({
-          client_id,
-          request_uri,
-          request_uri_method: value,
-          request: value,
-          state: value
-        })
-      ).toEqual({ client_id, request_uri, request_uri_method: "get" });
-    },
-  );
+  it.each([null, undefined])("handles optional (%s) values", (value) => {
+    expect(
+      startFlowFromQR({
+        client_id,
+        request: value,
+        request_uri,
+        request_uri_method: value,
+        state: value,
+      }),
+    ).toEqual({ client_id, request_uri, request_uri_method: "get" });
+  });
 });

--- a/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
+++ b/src/credentials-catalogue/api/DigitalCredentialsCatalogue.ts
@@ -73,9 +73,9 @@ export const CredentialFormat = z.object({
   configuration_id: z.string(),
   docType: z.string().optional(),
   format: z.enum(["dc+sd-jwt", "mso_mdoc"]),
-  schema_uri: z.string().url().optional(),
+  schema_uri: z.url().optional(),
   "schema_uri#integrity": z.string().optional(),
-  vct: z.string().url().optional(),
+  vct: z.url().optional(),
 });
 export type CredentialFormat = z.infer<typeof CredentialFormat>;
 
@@ -161,7 +161,7 @@ export const DigitalCredentialsCatalogue = z.object({
   iat: UnixTime,
   localization: LocalizationInfo.optional(),
   taxonomy: Taxonomy.optional(),
-  taxonomy_uri: z.string().url(),
+  taxonomy_uri: z.url(),
 });
 export type DigitalCredentialsCatalogue = z.infer<
   typeof DigitalCredentialsCatalogue

--- a/src/credentials-catalogue/v1.0.0/types.ts
+++ b/src/credentials-catalogue/v1.0.0/types.ts
@@ -39,9 +39,9 @@ const CredentialFormat = z.object({
   configuration_id: z.string(),
   docType: z.string().optional(),
   format: z.enum(["dc+sd-jwt", "mso_mdoc"]),
-  schema_uri: z.string().url().optional(),
+  schema_uri: z.url().optional(),
   "schema_uri#integrity": z.string().optional(),
-  vct: z.string().url().optional(),
+  vct: z.url().optional(),
 });
 
 const Claim = z.object({
@@ -90,7 +90,7 @@ export const DigitalCredentialsCatalogueJwt = z.object({
     credentials: z.array(DigitalCredential),
     exp: UnixTime,
     iat: UnixTime,
-    taxonomy_uri: z.string().url(),
+    taxonomy_uri: z.url(),
   }),
 });
 export type DigitalCredentialsCatalogueJwt = z.infer<

--- a/src/sd-jwt/types.ts
+++ b/src/sd-jwt/types.ts
@@ -77,8 +77,8 @@ export const TypeMetadata = z.object({
   data_source: z.object({
     authentic_source: z.object({
       contacts: z.array(z.string()),
-      homepage_uri: z.string().url(),
-      logo_uri: z.string().url(),
+      homepage_uri: z.url(),
+      logo_uri: z.url(),
       organization_code: z.string(),
       organization_name: z.string(),
     }),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Strip null values from the QR code parameters to validate, default request_uri_method to `get`
- Added tests
- Replaced deprecated Zod `string().url()` with `url()`

#### Motivation and Context

This PR makes `startFlowFromQR` more tolerant with null or missing optional values in the QR code payload of remote presentations.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
