### PR TITLE
chore: Anonymize fiscal codes in `IssuerResponseError` reason

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,11 +143,11 @@
     ]
   },
   "dependencies": {
-    "@pagopa/io-wallet-oauth2": "1.5.4",
-    "@pagopa/io-wallet-oid-federation": "1.5.4",
-    "@pagopa/io-wallet-oid4vci": "1.5.4",
-    "@pagopa/io-wallet-oid4vp": "1.5.4",
-    "@pagopa/io-wallet-utils": "1.5.4",
+    "@pagopa/io-wallet-oauth2": "1.5.6",
+    "@pagopa/io-wallet-oid-federation": "1.5.6",
+    "@pagopa/io-wallet-oid4vci": "1.5.6",
+    "@pagopa/io-wallet-oid4vp": "1.5.6",
+    "@pagopa/io-wallet-utils": "1.5.6",
     "@sd-jwt/core": "^0.19.0",
     "@sd-jwt/crypto-nodejs": "^0.19.0",
     "@sd-jwt/jwt-status-list": "^0.19.0",

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -84,6 +84,58 @@ describe("extractErrorMessageFromIssuerConf", () => {
   });
 });
 
+describe("UnexpectedStatusCodeError", () => {
+  const fiscalCode = "LVLDAA85T50G702B";
+  const fiscalCodeMask = "*".repeat(16);
+
+  it("anonymizes fiscal codes in a string reason", () => {
+    const error = new UnexpectedStatusCodeError({
+      message: "A message",
+      reason: `User ${fiscalCode} not found`,
+      statusCode: 404,
+    });
+
+    expect(error.reason).toBe(`User ${fiscalCodeMask} not found`);
+  });
+
+  it("leaves a string reason without fiscal codes unchanged", () => {
+    const error = new UnexpectedStatusCodeError({
+      message: "A message",
+      reason: "credential_not_found",
+      statusCode: 404,
+    });
+
+    expect(error.reason).toBe("credential_not_found");
+  });
+
+  it("anonymizes fiscal codes in an object reason", () => {
+    const error = new UnexpectedStatusCodeError({
+      message: "A message",
+      reason: {
+        error: "tax_id_code_mismatch",
+        error_description: `Mismatch for ${fiscalCode}`,
+      },
+      statusCode: 400,
+    });
+
+    expect(error.reason).toEqual({
+      error: "tax_id_code_mismatch",
+      error_description: `Mismatch for ${fiscalCodeMask}`,
+    });
+  });
+
+  it("is inherited by IssuerResponseError", () => {
+    const error = new IssuerResponseError({
+      code: IssuerResponseErrorCodes.IssuerGenericError,
+      message: "A message",
+      reason: `User ${fiscalCode} not found`,
+      statusCode: 404,
+    });
+
+    expect(error.reason).toBe(`User ${fiscalCodeMask} not found`);
+  });
+});
+
 describe("ResponseErrorBuilder", () => {
   const errorBuilderWithFallback = new ResponseErrorBuilder(IssuerResponseError)
     .handle(403, {

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -84,12 +84,12 @@ describe("extractErrorMessageFromIssuerConf", () => {
   });
 });
 
-describe("UnexpectedStatusCodeError", () => {
+describe("IssuerResponseError", () => {
   const fiscalCode = "LVLDAA85T50G702B";
   const fiscalCodeMask = "*".repeat(16);
 
   it("anonymizes fiscal codes in a string reason", () => {
-    const error = new UnexpectedStatusCodeError({
+    const error = new IssuerResponseError({
       message: "A message",
       reason: `User ${fiscalCode} not found`,
       statusCode: 404,
@@ -99,7 +99,7 @@ describe("UnexpectedStatusCodeError", () => {
   });
 
   it("leaves a string reason without fiscal codes unchanged", () => {
-    const error = new UnexpectedStatusCodeError({
+    const error = new IssuerResponseError({
       message: "A message",
       reason: "credential_not_found",
       statusCode: 404,
@@ -109,7 +109,7 @@ describe("UnexpectedStatusCodeError", () => {
   });
 
   it("anonymizes fiscal codes in an object reason", () => {
-    const error = new UnexpectedStatusCodeError({
+    const error = new IssuerResponseError({
       message: "A message",
       reason: {
         error: "tax_id_code_mismatch",
@@ -122,17 +122,6 @@ describe("UnexpectedStatusCodeError", () => {
       error: "tax_id_code_mismatch",
       error_description: `Mismatch for ${fiscalCodeMask}`,
     });
-  });
-
-  it("is inherited by IssuerResponseError", () => {
-    const error = new IssuerResponseError({
-      code: IssuerResponseErrorCodes.IssuerGenericError,
-      message: "A message",
-      reason: `User ${fiscalCode} not found`,
-      statusCode: 404,
-    });
-
-    expect(error.reason).toBe(`User ${fiscalCodeMask} not found`);
   });
 });
 

--- a/src/utils/__tests__/string.tests.ts
+++ b/src/utils/__tests__/string.tests.ts
@@ -1,4 +1,7 @@
-import { obfuscateString } from "../string";
+import { anonymizeString, obfuscateString } from "../string";
+
+const FISCAL_CODE = "LVLDAA85T50G702B";
+const FISCAL_CODE_MASK = "*".repeat(16);
 
 describe("obfuscateString", () => {
   it("should return empty string when input is empty", () => {
@@ -42,5 +45,51 @@ describe("obfuscateString", () => {
     const input = "test123";
     const result = obfuscateString(input);
     expect(result.length).toBe(input.length);
+  });
+});
+
+describe("anonymizeString", () => {
+  it("replaces a fiscal code in a string", () => {
+    expect(anonymizeString(`User ${FISCAL_CODE} not found`)).toBe(
+      `User ${FISCAL_CODE_MASK} not found`,
+    );
+  });
+
+  it("replaces every fiscal code in a string", () => {
+    expect(anonymizeString(`${FISCAL_CODE} and rssmra85t10a562s`)).toBe(
+      `${FISCAL_CODE_MASK} and ${FISCAL_CODE_MASK}`,
+    );
+  });
+
+  it("leaves strings without a fiscal code unchanged", () => {
+    expect(anonymizeString("credential_not_found")).toBe(
+      "credential_not_found",
+    );
+  });
+
+  it("replaces fiscal codes in nested object string values", () => {
+    expect(
+      anonymizeString({
+        error: "invalid_request",
+        error_description: `Mismatch for ${FISCAL_CODE}`,
+        nested: { tax_id: FISCAL_CODE },
+      }),
+    ).toEqual({
+      error: "invalid_request",
+      error_description: `Mismatch for ${FISCAL_CODE_MASK}`,
+      nested: { tax_id: FISCAL_CODE_MASK },
+    });
+  });
+
+  it("replaces fiscal codes in arrays", () => {
+    expect(anonymizeString([FISCAL_CODE, "ok"])).toEqual([
+      FISCAL_CODE_MASK,
+      "ok",
+    ]);
+  });
+
+  it("leaves non-string primitives unchanged", () => {
+    expect(anonymizeString(404)).toBe(404);
+    expect(anonymizeString(null)).toBe(null);
   });
 });

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -11,6 +11,7 @@ import {
   type WalletProviderResponseErrorCode,
   WalletProviderResponseErrorCodes,
 } from "./error-codes";
+import { anonymizeString } from "./string";
 
 export {
   IssuerResponseErrorCodes,
@@ -106,11 +107,17 @@ export class IoWalletError extends Error {
 
 /**
  * An error subclass thrown when an HTTP request has a status code different from the one expected.
+ * `reason` values are returned with Italian fiscal codes anonymized.
  */
 export class UnexpectedStatusCodeError extends IoWalletError {
   code = "ERR_UNEXPECTED_STATUS_CODE";
-  reason: GenericErrorReason;
   statusCode: number;
+
+  get reason(): GenericErrorReason {
+    return anonymizeString(this._reason);
+  }
+
+  private _reason: GenericErrorReason;
 
   constructor({
     message,
@@ -122,7 +129,7 @@ export class UnexpectedStatusCodeError extends IoWalletError {
     statusCode: number;
   }) {
     super(serializeAttrs({ message, reason, statusCode }));
-    this.reason = reason;
+    this._reason = reason;
     this.statusCode = statusCode;
   }
 }
@@ -198,7 +205,10 @@ export class ValidationFailed extends IoWalletError {
  */
 export class WalletProviderResponseError extends UnexpectedStatusCodeError {
   code: WalletProviderResponseErrorCode;
-  reason: ProblemJson;
+
+  get reason(): ProblemJson {
+    return super.reason as ProblemJson;
+  }
 
   constructor(params: {
     code?: WalletProviderResponseErrorCode;
@@ -207,7 +217,6 @@ export class WalletProviderResponseError extends UnexpectedStatusCodeError {
     statusCode: number;
   }) {
     super(params);
-    this.reason = params.reason;
     this.code =
       params.code ??
       WalletProviderResponseErrorCodes.WalletProviderGenericError;
@@ -322,7 +331,11 @@ export class ResponseErrorBuilder<T extends typeof UnexpectedStatusCodeError> {
       this.errorCases[originalError.statusCode] ?? this.errorCases["*"];
 
     if (params) {
-      return new this.ErrorClass({ ...originalError, ...params });
+      return new this.ErrorClass({
+        reason: originalError.reason,
+        statusCode: originalError.statusCode,
+        ...params,
+      });
     }
 
     return originalError;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -107,17 +107,11 @@ export class IoWalletError extends Error {
 
 /**
  * An error subclass thrown when an HTTP request has a status code different from the one expected.
- * `reason` values are returned with Italian fiscal codes anonymized.
  */
 export class UnexpectedStatusCodeError extends IoWalletError {
   code = "ERR_UNEXPECTED_STATUS_CODE";
+  reason: GenericErrorReason;
   statusCode: number;
-
-  get reason(): GenericErrorReason {
-    return anonymizeString(this._reason);
-  }
-
-  private _reason: GenericErrorReason;
 
   constructor({
     message,
@@ -129,7 +123,7 @@ export class UnexpectedStatusCodeError extends IoWalletError {
     statusCode: number;
   }) {
     super(serializeAttrs({ message, reason, statusCode }));
-    this._reason = reason;
+    this.reason = reason;
     this.statusCode = statusCode;
   }
 }
@@ -137,6 +131,7 @@ export class UnexpectedStatusCodeError extends IoWalletError {
 /**
  * An error subclass thrown when an Issuer HTTP request fails.
  * The specific error can be found in the `code` property.
+ * `reason` values are returned with Italian fiscal codes anonymized.
  */
 export class IssuerResponseError extends UnexpectedStatusCodeError {
   code: IssuerResponseErrorCode;
@@ -147,7 +142,7 @@ export class IssuerResponseError extends UnexpectedStatusCodeError {
     reason: GenericErrorReason;
     statusCode: number;
   }) {
-    super(params);
+    super({ ...params, reason: anonymizeString(params.reason) });
     this.code = params.code ?? IssuerResponseErrorCodes.IssuerGenericError;
   }
 }
@@ -205,10 +200,7 @@ export class ValidationFailed extends IoWalletError {
  */
 export class WalletProviderResponseError extends UnexpectedStatusCodeError {
   code: WalletProviderResponseErrorCode;
-
-  get reason(): ProblemJson {
-    return super.reason as ProblemJson;
-  }
+  reason: ProblemJson;
 
   constructor(params: {
     code?: WalletProviderResponseErrorCode;
@@ -217,6 +209,7 @@ export class WalletProviderResponseError extends UnexpectedStatusCodeError {
     statusCode: number;
   }) {
     super(params);
+    this.reason = params.reason;
     this.code =
       params.code ??
       WalletProviderResponseErrorCodes.WalletProviderGenericError;

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,3 +1,54 @@
+import { isObject } from "./object";
+
+/**
+ * Italian codice fiscale, including omocodia.
+ * Anchors from the source validator are omitted so matches can be found inside longer strings.
+ * Built per call so a shared `/g` regex cannot leak `lastIndex`.
+ *
+ * @see https://gist.github.com/matpag/242557b056865aa2c8e0edb27bbb6822#file-italian_tax_code_regex-txt
+ */
+const ITALIAN_FISCAL_CODE_SOURCE =
+  "(?:[A-Z][AEIOUX][AEIOUX]|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}(?:[\\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[15MR][\\dLMNP-V]|[26NS][0-8LMNP-U])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM]|[AC-EHLMPR-T][26NS][9V])|(?:[02468LNQSU][048LQU]|[13579MPRTV][26NS])B[26NS][9V])(?:[A-MZ][1-9MNP-V][\\dLMNP-V]{2}|[A-M][0L](?:[1-9MNP-V][\\dLMNP-V]|[0L][1-9MNP-V]))[A-Z]";
+
+const FISCAL_CODE_MASK = "*".repeat(16);
+
+/**
+ * Replaces Italian fiscal codes with 16 asterisks.
+ * Walks strings, arrays, and nested objects; other values pass through.
+ *
+ * @example
+ * ```ts
+ * anonymizeString("User LVLDAA85T50G702B not found");
+ * // "User **************** not found"
+ *
+ * anonymizeString({ tax_id: "LVLDAA85T50G702B" });
+ * // { tax_id: "****************" }
+ * ```
+ */
+export const anonymizeString = <T>(value: T): T => {
+  if (typeof value === "string") {
+    return value.replace(
+      new RegExp(ITALIAN_FISCAL_CODE_SOURCE, "gi"),
+      FISCAL_CODE_MASK,
+    ) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => anonymizeString(item)) as T;
+  }
+
+  if (isObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [
+        key,
+        anonymizeString(nested),
+      ]),
+    ) as T;
+  }
+
+  return value;
+};
+
 /**
  * Randomly obfuscates characters in a string by replacing them with a specified character.
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -3037,58 +3037,58 @@
     js-base64 "^3.7.7"
     zod "^3.22.4"
 
-"@pagopa/io-wallet-oauth2@1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oauth2/-/io-wallet-oauth2-1.5.4.tgz#9b4c78d6c13a6cfb41d4581276cbdb4d3d2fa3b7"
-  integrity sha512-LPNoZbrSc/Nj0ax5hAO6+r+lQnRPMDabmKPSFhS5bhc7685h5kW2KuC4QjS1Y6HyBvKgZeYohYW9BDcbbPfm1g==
+"@pagopa/io-wallet-oauth2@1.5.6":
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oauth2/-/io-wallet-oauth2-1.5.6.tgz#27f22237b3492eb65ea27f78ad62bed981ce4bd1"
+  integrity sha512-7/4Hw/BKxsPqnnbUkv/IwjrHeuIFISbxmxdXWvN2NdTPte+eL+UFMMkzH6MgYDwJbshd9DaJQlVQgECGZHEWFw==
   dependencies:
     "@openid4vc/oauth2" "0.4.3"
     "@openid4vc/utils" "0.4.3"
-    "@pagopa/io-wallet-oid-federation" "1.5.4"
-    "@pagopa/io-wallet-utils" "1.5.4"
+    "@pagopa/io-wallet-oid-federation" "1.5.6"
+    "@pagopa/io-wallet-utils" "1.5.6"
     js-base64 "^3.7.8"
     zod "^4.3.6"
 
-"@pagopa/io-wallet-oid-federation@1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oid-federation/-/io-wallet-oid-federation-1.5.4.tgz#46e09204b2d8fcadcf95d0fb7269f895c0299341"
-  integrity sha512-G3HWvDBl1favjWuFDg+OAcLu99NFuf9ZNCmONejbWOVXbzhvzTCl4k6qCEY3GtwMaMdVP11lUdkfYbNowOoWCg==
+"@pagopa/io-wallet-oid-federation@1.5.6":
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oid-federation/-/io-wallet-oid-federation-1.5.6.tgz#d56b62f48bbe054f224ce9b0a833ddd266c607d5"
+  integrity sha512-ZdvLdEi1sqLg6we6Ca/wI99V1b6KCjYGZHzYYeRSCm1vyk7E0Du91HlZ4IYCYQ4+tfbQ+8amfHSh6uklM4+U7A==
   dependencies:
-    "@pagopa/io-wallet-utils" "1.5.4"
+    "@pagopa/io-wallet-utils" "1.5.6"
     buffer "^6.0.3"
     zod "^4.3.6"
 
-"@pagopa/io-wallet-oid4vci@1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oid4vci/-/io-wallet-oid4vci-1.5.4.tgz#db42fb98d8c2dc88b723e1f661085ecded93596c"
-  integrity sha512-dapcXkVpD0wqxHZwhQUrJtE1eST0fRTxAuqrHzgU5XQo4fiEPfpse39uPRu+rec7kKVZbx7gw0uhoqVFLgGdaw==
+"@pagopa/io-wallet-oid4vci@1.5.6":
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oid4vci/-/io-wallet-oid4vci-1.5.6.tgz#5bfead4081643bd72a7c6dd7bc6ee2a3cbe28e42"
+  integrity sha512-+lMK3xuPRanduGfLlgtCydyPctnqn+3ulrGckvWviJ7iV6Xsxp1DVVTqets4UJUPMXX143sAldRZmvD5NtN1LQ==
   dependencies:
     "@openid4vc/oauth2" "0.4.3"
     "@openid4vc/openid4vci" "0.4.3"
     "@openid4vc/utils" "0.4.3"
-    "@pagopa/io-wallet-oauth2" "1.5.4"
-    "@pagopa/io-wallet-oid-federation" "1.5.4"
-    "@pagopa/io-wallet-oid4vp" "1.5.4"
-    "@pagopa/io-wallet-utils" "1.5.4"
+    "@pagopa/io-wallet-oauth2" "1.5.6"
+    "@pagopa/io-wallet-oid-federation" "1.5.6"
+    "@pagopa/io-wallet-oid4vp" "1.5.6"
+    "@pagopa/io-wallet-utils" "1.5.6"
     zod "^4.3.6"
 
-"@pagopa/io-wallet-oid4vp@1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oid4vp/-/io-wallet-oid4vp-1.5.4.tgz#f5888b273b1873449c3a40ed1be49bbf2d354d81"
-  integrity sha512-QnVkEHVNUHMQnUTxAaAVHkK06PjPTsF9g1EUNOxr/KsATjYa5exN5dz31lNdl7DupIBX/ponBS7pRxDsTMdxpw==
+"@pagopa/io-wallet-oid4vp@1.5.6":
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-oid4vp/-/io-wallet-oid4vp-1.5.6.tgz#14a4f15a0e96c18877a25fe4be7041b09043f476"
+  integrity sha512-NrZBw92v/vLX0BnvoxeNzIxBDbdUdRXv1xIlY2D+sreNGhGzeidCaMgWJpFKoSNiYOPWOFZiqBcA6ozho35h9w==
   dependencies:
     "@openid4vc/oauth2" "0.4.3"
     "@openid4vc/openid4vp" "0.4.3"
     "@openid4vc/utils" "0.4.3"
-    "@pagopa/io-wallet-oauth2" "1.5.4"
-    "@pagopa/io-wallet-oid-federation" "1.5.4"
-    "@pagopa/io-wallet-utils" "1.5.4"
+    "@pagopa/io-wallet-oauth2" "1.5.6"
+    "@pagopa/io-wallet-oid-federation" "1.5.6"
+    "@pagopa/io-wallet-utils" "1.5.6"
     zod "^4.3.6"
 
-"@pagopa/io-wallet-utils@1.5.4":
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-utils/-/io-wallet-utils-1.5.4.tgz#223fd419e2aeb5991a5766f5b7e6f5c40490e75f"
-  integrity sha512-wX1WGFQedLJutBGOcz7QdQqp7N710ii/MEITJypxfiaJQFsXTUZUsux4ZWH1FYPhZUC6WVBX+0s+APyRRsZCew==
+"@pagopa/io-wallet-utils@1.5.6":
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-wallet-utils/-/io-wallet-utils-1.5.6.tgz#017e378f4629cf001be8ab02068689fefa308075"
+  integrity sha512-T0UjR7P5fqE7IRAa7GUFFRfSFsd1GbsAy1XUx9cckVKd8dysFoOpW94i74Yuzo3iZRi9nVSn5Q3uuem1du7kLA==
   dependencies:
     "@openid4vc/oauth2" "0.4.3"
     "@openid4vc/utils" "0.4.3"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- `IssuerResponseError` runs `reason` through `anonymizeString` before `super()`, so both `reason` and the serialized `Error.message` replace Italian fiscal codes (codice fiscale, including omocodia) with 16 asterisks
- added `anonymizeString` in `src/utils/string.ts`: walks strings, arrays, and nested objects; other values pass through. The fiscal-code regex is built per call so a shared `/g` `lastIndex` cannot leak
- `ResponseErrorBuilder.buildFrom` passes `reason` and `statusCode` into the specialized error constructor instead of spreading the original `Error` instance
- `UnexpectedStatusCodeError`, `WalletProviderResponseError`, and `RelyingPartyResponseError` are unchanged

#### Motivation and Context

Credential issuer error payloads can include a codice fiscale in `reason`. App code logs and displays that field. This PR strips fiscal codes from `IssuerResponseError` only, which is the type consumers see for issuer HTTP failures.

#### How Has This Been Tested?

Unit tests:
- `anonymizeString`: one or many fiscal codes in a string, nested objects, arrays, primitives, strings with no fiscal code
- `IssuerResponseError`: string `reason`, object `reason`, `reason` with no fiscal code

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.